### PR TITLE
fix(mosque-finder): mirror grid layout for Arabic (RTL) reading direction

### DIFF
--- a/app/[locale]/mosque-finder/client.tsx
+++ b/app/[locale]/mosque-finder/client.tsx
@@ -194,8 +194,8 @@ out center tags 60;`;
       </div>
 
       {/* map + results */}
-      <div className="mt-6 grid gap-4 lg:grid-cols-[1.35fr_1fr]">
-        <div className="relative lg:sticky lg:top-20 lg:self-start">
+      <div className="mt-6 grid gap-4 lg:grid-cols-[1.35fr_1fr] rtl:lg:grid-cols-[1fr_1.35fr]">
+        <div className="relative order-1 lg:order-1 rtl:lg:order-2 lg:sticky lg:top-20 lg:self-start">
           <OsmMap
             center={center}
             zoom={zoom}
@@ -226,7 +226,7 @@ out center tags 60;`;
           </button>
         </div>
 
-        <div>
+        <div className="order-2 lg:order-2 rtl:lg:order-1">
           {status === "done" && mosques.length > 0 ? (
             <>
               <p className={`mb-3 text-sm font-medium ${mutedCls}`}>{t.resultCount(mosques.length)}</p>

--- a/components/osm-map.tsx
+++ b/components/osm-map.tsx
@@ -132,6 +132,7 @@ export function OsmMap({
   return (
     <div
       ref={ref}
+      dir="ltr"
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
@@ -199,7 +200,7 @@ export function OsmMap({
       </div>
 
       {/* zoom controls */}
-      <div className="absolute right-3 top-3 flex flex-col overflow-hidden rounded-lg border border-black/10 bg-white shadow-sm dark:border-white/10 dark:bg-zinc-900">
+      <div className="absolute end-3 top-3 flex flex-col overflow-hidden rounded-lg border border-black/10 bg-white shadow-sm dark:border-white/10 dark:bg-zinc-900">
         {([["ph:plus", 1], ["ph:minus", -1]] as const).map(([icon, delta]) => (
           <button
             key={icon}
@@ -219,7 +220,7 @@ export function OsmMap({
         target="_blank"
         rel="noreferrer"
         onPointerDown={(e) => e.stopPropagation()}
-        className="absolute bottom-0 right-0 bg-white/80 px-1.5 py-0.5 text-[10px] text-zinc-600 hover:underline dark:bg-zinc-900/80 dark:text-zinc-300"
+        className="absolute bottom-0 end-0 bg-white/80 px-1.5 py-0.5 text-[10px] text-zinc-600 hover:underline dark:bg-zinc-900/80 dark:text-zinc-300"
       >
         © OpenStreetMap
       </a>


### PR DESCRIPTION
### Summary of Changes
- **Arabic (RTL) Layout Fix**: Mirrored the Mosque Finder (`/ar/mosque-finder`) grid layout so the results list is placed on the **right** side (matching natural right-to-left reading flow) and the map on the **left** side.
- **OsmMap Canvas Isolation**: Added `dir="ltr"` to the root canvas container in `components/osm-map.tsx` to isolate map Mercator coordinate calculations from page-level RTL text direction.
- **Logical CSS Properties**: Updated map zoom controls to use logical property `end-3 top-3`.
- **Preserved Design**: English (LTR) mode and mobile responsive viewports remain fully intact.
### Testing
- Verified on desktop & mobile viewports in both `/ar/mosque-finder` and `/en/mosque-finder`.
- Ran `npx tsc --noEmit` & `npm run lint` with 0 errors.