### PR TITLE
feat: implement Quran browsing functionality with multi-language support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ next-env.d.ts
 
 # video
 *.mp4
+
+# Quran editions cached for the prerendered /quran routes (npm run prebuild)
+/.quran-cache/

--- a/README.md
+++ b/README.md
@@ -75,6 +75,29 @@ Most modern Islamic apps rely on invasive location tracking, aggressive ads, or 
   - ⚡ Playback speed control
   - 🔤 Adjustable Arabic font size
   - 🌙 Dark mode and responsive design
+  - 🔗 Every reading unit has its own prerendered page — see below
+
+### Quran URL structure
+
+Beyond the interactive reader at `/quran`, the whole Quran is prerendered as
+static, indexable pages — four views of the same text, one per way people
+actually look it up:
+
+| Route | Count | Example |
+|-------|-------|---------|
+| `/[locale]/quran/surah/[slug]` | 114 | [`/en/quran/surah/al-kahf`](https://falah.io/en/quran/surah/al-kahf/) |
+| `/[locale]/quran/juz/[n]` | 30 | [`/en/quran/juz/30`](https://falah.io/en/quran/juz/30/) |
+| `/[locale]/quran/hizb/[n]` | 60 | [`/en/quran/hizb/59`](https://falah.io/en/quran/hizb/59/) |
+| `/[locale]/quran/page/[n]` | 604 | [`/en/quran/page/255`](https://falah.io/en/quran/page/255/) |
+
+Each page ships the full Arabic text and translation in the HTML (no
+client-side fetch), with its own title, description, canonical, hreflang and
+`schema.org` `Chapter` / `Book` data. Surah slugs are fixed in
+`lib/quran-meta.ts` so URLs never shift with an upstream API's spelling.
+
+The text is downloaded once by `npm run prebuild` into `.quran-cache/`
+(git-ignored) — `next build` renders ~1,600 pages across parallel workers, so
+they read from disk rather than hitting the API each.
 
 - **Tafseer Explorer**
   - Read explanations and commentary alongside verses.

--- a/app/[locale]/quran/client.tsx
+++ b/app/[locale]/quran/client.tsx
@@ -2,28 +2,25 @@
 
 import { Icon } from "@iconify/react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useDict } from "@/components/locale";
+import { useDict, useLocale } from "@/components/locale";
 import { goldCls, lineCls, mutedCls, Star8, StarField, ToolShell } from "@/components/ui";
-import {
-  type Ayah,
-  fetchPageEditions,
-  fetchSurahEditions,
-  type Surah,
-  TOTAL_PAGES,
-  useSurahs,
-} from "@/lib/quran";
-import { type Anchor, anchorFromEvent, AyahTooltip } from "./ayah-tooltip";
+import { stripLeadingBasmala } from "@/lib/arabic";
+import { SURAHS, type SurahMeta, TOTAL_PAGES } from "@/lib/quran-meta";
 import {
   type BrowseMode,
-  ControlsPanel,
-  iconBtnCls,
-  type QuranUi,
+  fetchUnitTranslation,
+  type ReaderAyah,
+  type ReaderUnit,
   RECITERS,
-  SeekBar,
   SPEEDS,
-  type TransMode,
-} from "./controls";
+  audioUrl,
+  unitOf,
+  unitPath,
+} from "@/lib/quran-reader";
+import { type Anchor, anchorFromEvent, AyahTooltip } from "./ayah-tooltip";
+import { ControlsPanel, iconBtnCls, type QuranUi, SeekBar, type TransMode } from "./controls";
 
 const BISMILLAH = "بِسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ";
 const AR_DIGITS = ["٠", "١", "٢", "٣", "٤", "٥", "٦", "٧", "٨", "٩"];
@@ -33,15 +30,10 @@ const toArabicNum = (n: number) =>
     .map((c) => AR_DIGITS[Number(c)] ?? c)
     .join("");
 
-const DIACRITICS = /[ؐ-ًؚ-ٰٟۖ-ۭ]/g;
-
-/** For surahs other than Al-Fatiha, the Uthmani text prefixes the basmala to
- * the first verse. Drop it so it can be shown as its own ornamental line. */
-function stripLeadingBasmala(text: string): string {
-  const words = text.trim().split(/\s+/);
-  const bare = (words[0] ?? "").replace(DIACRITICS, "");
-  return bare === "بسم" ? words.slice(4).join(" ") : text;
-}
+/** Set just before navigating to the next unit, so the recitation picks back
+ * up on the other side. sessionStorage survives the navigation; React state
+ * does not. */
+const AUTOPLAY_KEY = "falah:quran:autoplay";
 
 /** The 8-pointed star medallion that closes each verse. */
 function AyahMark({ n }: { n: number }) {
@@ -53,38 +45,38 @@ function AyahMark({ n }: { n: number }) {
   );
 }
 
-/** A run of consecutive verses from one surah. A mushaf page can straddle two
- * surahs, so the text is drawn in runs rather than as a single block. */
-type Segment = { key: string; surah?: Surah; items: { ayah: Ayah; i: number }[] };
+/** A run of consecutive verses from one surah — a juz, hizb or mushaf page
+ * routinely straddles two, so the text is drawn in runs. */
+type Segment = { key: string; surah: SurahMeta; items: { ayah: ReaderAyah; i: number }[] };
 
-export default function QuranClient() {
+export default function QuranClient({
+  unit,
+  heading,
+  children,
+}: {
+  unit: ReaderUnit;
+  /** H1, Arabic ornament and intro prose for this URL — built server-side
+   * from the same strings the <title> and meta description use. */
+  heading: { title: string; side: string; intro: string };
+  /** Server-rendered links (the hub directory, or a unit's related units) —
+   * already HTML, so crawlers see them without running any JavaScript. */
+  children?: React.ReactNode;
+}) {
   const d = useDict();
+  const locale = useLocale();
   const t = d.tools.quran;
   const reduce = useReducedMotion();
-  const { surahs, error: listError } = useSurahs();
+  const router = useRouter();
 
-  const [mode, setMode] = useState<BrowseMode>("surah");
-  const [surahNumber, setSurahNumber] = useState(1);
-  const [pageNumber, setPageNumber] = useState(1);
   const [reciter, setReciter] = useState(RECITERS[0].id);
-  const [transEdition, setTransEdition] = useState(t.translationEdition);
+  const [transEdition, setTransEdition] = useState(unit.edition);
   const [transMode, setTransMode] = useState<TransMode>("hover");
   const [scale, setScale] = useState(1);
   const [speed, setSpeed] = useState(1);
 
-  const [content, setContent] = useState<{
-    key: string;
-    /** The browse mode and surah/page this text was fetched for — rendering
-     * reads these, not the live state, so a pending fetch can't relabel the
-     * text still on screen. */
-    mode: BrowseMode;
-    unit: number;
-    arabic: Ayah[];
-    translation: Ayah[];
-  } | null>(null);
-  const [audio, setAudio] = useState<{ key: string; ayahs: Ayah[] } | null>(null);
-  // Tagged with the request it belongs to, so navigating away retires it.
-  const [err, setErr] = useState<{ key: string; msg: string } | null>(null);
+  /** Only set when the reader switches away from the edition this page was
+   * built with; otherwise the prerendered translation is used as-is. */
+  const [override, setOverride] = useState<{ edition: string; texts: string[] } | null>(null);
 
   const [activeIdx, setActiveIdx] = useState<number | null>(null);
   const [anchor, setAnchor] = useState<Anchor | null>(null);
@@ -97,69 +89,41 @@ export default function QuranClient() {
   const [sheetOpen, setSheetOpen] = useState(false);
 
   const audioRef = useRef<HTMLAudioElement>(null);
-  const shouldAutoPlayFirstAyah = useRef(false);
   const hoverCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const unit = mode === "surah" ? surahNumber : pageNumber;
-  const contentKey = `${mode}:${unit}:${transEdition}`;
-  const audioKey = `${mode}:${unit}:${reciter}`;
+  const ayahs = unit.ayahs;
 
-  // Arabic text + translation, refetched when the surah/page or translation changes.
+  // A different translation is the one thing still worth a network call.
   useEffect(() => {
+    // The prerendered edition needs no fetch; translationAt() already ignores
+    // a stale override, so there is nothing to reset here.
+    if (transEdition === unit.edition) return;
     let cancelled = false;
-    const key = `${mode}:${unit}:${transEdition}`;
-    const editions = ["quran-uthmani", transEdition];
-    const load =
-      mode === "surah" ? fetchSurahEditions(unit, editions) : fetchPageEditions(unit, editions);
-    load
-      .then(([arabic, translation]) => {
-        if (!cancelled) {
-          setContent({ key, mode, unit, arabic, translation });
-          setErr(null);
+    fetchUnitTranslation(unit.mode, unit.n, transEdition)
+      .then((texts) => {
+        if (!cancelled && texts.length === ayahs.length) {
+          setOverride({ edition: transEdition, texts });
         }
       })
       .catch(() => {
-        if (!cancelled) setErr({ key, msg: t.errSurah });
+        if (!cancelled) setOverride(null);
       });
     return () => {
       cancelled = true;
     };
-  }, [mode, unit, transEdition, t.errSurah]);
+  }, [transEdition, unit.edition, unit.mode, unit.n, ayahs.length]);
 
-  // Recitation audio, refetched only when the surah/page or reciter changes.
+  const translationAt = (i: number) =>
+    override?.edition === transEdition ? (override.texts[i] ?? "") : (ayahs[i]?.translation ?? "");
+
+  // Resume the recitation after rolling into the next surah, juz, hizb or page.
   useEffect(() => {
-    let cancelled = false;
-    const key = `${mode}:${unit}:${reciter}`;
-    const load =
-      mode === "surah" ? fetchSurahEditions(unit, [reciter]) : fetchPageEditions(unit, [reciter]);
-    load
-      .then(([ayahs]) => {
-        if (!cancelled) setAudio({ key, ayahs });
-      })
-      .catch(() => {
-        if (!cancelled) setAudio(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [mode, unit, reciter]);
-
-  const ready = content?.key === contentKey ? content : null;
-  const audioReady = audio?.key === audioKey ? audio : null;
-  // While the next surah/page loads, keep the previous one on screen, dimmed —
-  // paging through the mushaf shouldn't flash a skeleton on every tap.
-  const shown = ready ?? content;
-  const errMsg = err?.key === contentKey ? err.msg : null;
-  const loading = !shown && !errMsg;
-
-  // Autoplay the first verse when playback rolls into the next surah or page.
-  useEffect(() => {
-    if (shouldAutoPlayFirstAyah.current && audioReady && audioReady.ayahs.length > 0) {
-      shouldAutoPlayFirstAyah.current = false;
-      playIdx(0);
-    }
+    if (typeof window === "undefined") return;
+    if (sessionStorage.getItem(AUTOPLAY_KEY) !== "1") return;
+    sessionStorage.removeItem(AUTOPLAY_KEY);
+    playIdx(0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [audioReady]);
+  }, []);
 
   // Escape or a click elsewhere dismisses the translation bubble — on touch
   // there is no pointer-leave to close it with.
@@ -191,67 +155,59 @@ export default function QuranClient() {
     };
   }, [sheetOpen]);
 
-  const surahMeta = surahs?.find((s) => s.number === surahNumber);
-  const currentJuz = shown?.arabic[0]?.juz;
   const transIsRtl = transEdition.startsWith("ar");
+  const currentJuz = ayahs[0]?.juz;
 
   /** Split the loaded verses into per-surah runs. */
   const segments: Segment[] = [];
-  shown?.arabic.forEach((ayah, i) => {
-    const s = ayah.surah ?? (shown.mode === "surah" ? surahMeta : undefined);
+  for (const [i, ayah] of ayahs.entries()) {
+    const surah = SURAHS[ayah.surah - 1];
     const last = segments.at(-1);
-    if (last && last.surah?.number === s?.number) last.items.push({ ayah, i });
-    else segments.push({ key: `${s?.number ?? "x"}-${i}`, surah: s, items: [{ ayah, i }] });
-  });
+    if (last && last.surah.n === surah.n) last.items.push({ ayah, i });
+    else segments.push({ key: `${surah.n}-${i}`, surah, items: [{ ayah, i }] });
+  }
 
   const labelFor = (i: number) => {
-    const a = shown?.arabic[i];
-    return t.verseRef(a?.surah?.number ?? surahNumber, a?.numberInSurah ?? i + 1);
+    const a = ayahs[i];
+    return t.verseRef(a?.surah ?? 1, a?.ayah ?? i + 1);
   };
 
   const focusIdx = playingIdx ?? activeIdx ?? 0;
   const headerSurah = segments[0]?.surah;
 
-  function resetPlayback() {
+  // ---- navigation: every unit is a URL ----
+
+  function goTo(mode: BrowseMode, n: number, autoplay = false) {
+    if (mode === unit.mode && n === unit.n) return;
     audioRef.current?.pause();
-    setIsPlaying(false);
-    setPlayingIdx(null);
-    setActiveIdx(null);
-    setAnchor(null);
-    setCurrentTime(0);
-    setDuration(0);
+    if (autoplay) sessionStorage.setItem(AUTOPLAY_KEY, "1");
+    router.push(unitPath(locale, mode, n));
   }
 
-  function goToSurah(n: number) {
-    const next = Math.min(114, Math.max(1, n));
-    if (mode === "surah" && next === surahNumber) return;
-    resetPlayback();
-    setMode("surah");
-    setSurahNumber(next);
-  }
-
-  function goToPage(n: number) {
-    const next = Math.min(TOTAL_PAGES, Math.max(1, n));
-    if (mode === "page" && next === pageNumber) return;
-    resetPlayback();
-    setMode("page");
-    setPageNumber(next);
-  }
-
-  /** Switching browse mode keeps your place: surah → the page the current
-   * verse sits on, page → the surah that verse belongs to. */
+  /** Switching the browse mode keeps your place: whichever verse you are on
+   * decides which juz / hizb / page / surah you land in. */
   function switchMode(next: BrowseMode) {
-    if (next === mode) return;
-    const at = shown?.arabic[focusIdx];
-    if (next === "page") goToPage(at?.page ?? 1);
-    else goToSurah(at?.surah?.number ?? surahNumber);
+    if (next === unit.mode) return;
+    const at = ayahs[focusIdx] ?? ayahs[0];
+    goTo(next, at ? unitOf(next, at) : 1);
   }
+
+  /** Step to the neighbouring unit, carrying the recitation with it. Returns
+   * false at the very start or end of the mushaf. */
+  function stepUnit(dir: 1 | -1, autoplay = false) {
+    const next = unit.n + dir;
+    if (next < 1 || next > (unit.mode === "surah" ? 114 : Infinity)) return false;
+    goTo(unit.mode, next, autoplay);
+    return true;
+  }
+
+  // ---- playback ----
 
   function playIdx(idx: number) {
-    const src = audioReady?.ayahs[idx]?.audio;
+    const a = ayahs[idx];
     const el = audioRef.current;
-    if (!src || !el) return;
-    el.src = src;
+    if (!a || !el) return;
+    el.src = audioUrl(reciter, a.n);
     el.playbackRate = speed;
     el.muted = isMuted;
     void el.play().catch(() => {});
@@ -272,10 +228,6 @@ export default function QuranClient() {
     else playIdx(playingIdx ?? activeIdx ?? 0);
   }
 
-  function cycleSpeed() {
-    applySpeed(SPEEDS[(SPEEDS.indexOf(speed) + 1) % SPEEDS.length]);
-  }
-
   function applySpeed(v: number) {
     setSpeed(v);
     if (audioRef.current) audioRef.current.playbackRate = v;
@@ -287,33 +239,14 @@ export default function QuranClient() {
     if (audioRef.current) audioRef.current.muted = next;
   }
 
-  function cycleRepeat() {
-    setRepeatMode((prev) => (prev === "off" ? "ayah" : prev === "ayah" ? "surah" : "off"));
-  }
-
-  /** Step to the neighbouring surah or page and pick the recitation back up.
-   * Returns false at the very start or end of the mushaf. */
-  function stepUnit(dir: 1 | -1) {
-    const next = (mode === "surah" ? surahNumber : pageNumber) + dir;
-    const max = mode === "surah" ? 114 : TOTAL_PAGES;
-    if (next < 1 || next > max) return false;
-    shouldAutoPlayFirstAyah.current = true;
-    if (mode === "surah") goToSurah(next);
-    else goToPage(next);
-    return true;
-  }
-
   function prevAyah() {
     if (playingIdx !== null && playingIdx > 0) playIdx(playingIdx - 1);
-    else stepUnit(-1);
+    else stepUnit(-1, true);
   }
 
   function nextAyah() {
-    if (audioReady && playingIdx !== null && playingIdx < audioReady.ayahs.length - 1) {
-      playIdx(playingIdx + 1);
-    } else {
-      stepUnit(1);
-    }
+    if (playingIdx !== null && playingIdx < ayahs.length - 1) playIdx(playingIdx + 1);
+    else stepUnit(1, true);
   }
 
   function onEnded() {
@@ -322,9 +255,9 @@ export default function QuranClient() {
       return;
     }
     const next = (playingIdx ?? -1) + 1;
-    if (audioReady && next < audioReady.ayahs.length) playIdx(next);
+    if (next < ayahs.length) playIdx(next);
     else if (repeatMode === "surah") playIdx(0);
-    else if (!stepUnit(1)) {
+    else if (!stepUnit(1, true)) {
       setIsPlaying(false);
       setPlayingIdx(null);
     }
@@ -332,8 +265,8 @@ export default function QuranClient() {
 
   function onSeek(e: React.ChangeEvent<HTMLInputElement>) {
     const val = Number(e.target.value);
-    if (!audioReady || audioReady.ayahs.length === 0) return;
-    const targetIdx = Math.min(audioReady.ayahs.length - 1, Math.max(0, Math.floor(val)));
+    if (ayahs.length === 0) return;
+    const targetIdx = Math.min(ayahs.length - 1, Math.max(0, Math.floor(val)));
     const fraction = val - targetIdx;
 
     if (targetIdx !== playingIdx) {
@@ -368,23 +301,15 @@ export default function QuranClient() {
     if (hoverCloseTimer.current) clearTimeout(hoverCloseTimer.current);
   }
 
-  const metaLine =
-    mode === "surah"
-      ? surahMeta
-        ? `${surahMeta.englishName} · ${t.revelation[surahMeta.revelationType] ?? surahMeta.revelationType} · ${surahMeta.numberOfAyahs} ${t.ayahs}`
-        : ""
-      : `${t.pageOf(pageNumber, TOTAL_PAGES)}${currentJuz ? ` · ${t.juz(currentJuz)}` : ""}`;
-
   const q: QuranUi = {
     t,
-    surahs,
-    mode,
+    b: d.quranBrowse,
+    locale,
+    mode: unit.mode,
+    n: unit.n,
     setMode: switchMode,
-    surahNumber,
-    pageNumber,
-    goToSurah,
-    goToPage,
-    metaLine,
+    goTo: (mode, n) => goTo(mode, n),
+    metaLine: unitMeta(),
     verseLabel: labelFor(focusIdx),
     reciter,
     setReciter: (id) => {
@@ -403,155 +328,193 @@ export default function QuranClient() {
     setScale,
     speed,
     setSpeed: applySpeed,
-    cycleSpeed,
+    cycleSpeed: () => applySpeed(SPEEDS[(SPEEDS.indexOf(speed) + 1) % SPEEDS.length]),
     repeatMode,
-    cycleRepeat,
+    cycleRepeat: () =>
+      setRepeatMode((p) => (p === "off" ? "ayah" : p === "ayah" ? "surah" : "off")),
     isMuted,
     toggleMute,
     isPlaying,
-    canPlay: !!audioReady,
+    canPlay: ayahs.length > 0,
     togglePlay,
     prevAyah,
     nextAyah,
     playingIdx,
-    totalAyahs: audioReady?.ayahs.length ?? shown?.arabic.length ?? 1,
+    totalAyahs: ayahs.length,
     currentTime,
     duration,
     onSeek,
   };
 
-  const tipText = anchor ? ready?.translation[anchor.idx]?.text : undefined;
+  function unitMeta() {
+    const b = d.quranBrowse;
+    if (unit.mode === "surah") {
+      const s = SURAHS[unit.n - 1];
+      const rev = s.revelation === "Meccan" ? b.meccan : b.medinan;
+      return `${rev} · ${b.ayahCount(s.ayahs)} · ${b.juz} ${s.juz}`;
+    }
+    if (unit.mode === "page") {
+      return `${b.page} ${unit.n} / ${TOTAL_PAGES} · ${b.juz} ${currentJuz ?? 1}`;
+    }
+    if (unit.mode === "hizb") {
+      return `${b.juz} ${Math.ceil(unit.n / 2)} · ${b.ayahCount(ayahs.length)}`;
+    }
+    return `${b.ayahCount(ayahs.length)} · ${b.hizb} ${ayahs[0]?.hizb ?? 1}`;
+  }
+
+  const tipText = anchor ? translationAt(anchor.idx) : undefined;
 
   return (
-    <ToolShell icon="ph:book-open-text" title={t.title} side={t.side} intro={t.intro} wide>
+    <ToolShell
+      icon="ph:book-open-text"
+      title={heading.title}
+      side={heading.side}
+      intro={heading.intro}
+      wide
+    >
       <div className="lg:grid lg:grid-cols-[minmax(0,1fr)_20rem] lg:items-start lg:gap-6">
         {/* ---- the mushaf ---- */}
         <div className="min-w-0">
-          {listError ? <p className="mb-4 text-sm text-red-600 dark:text-red-400">{t.errList}</p> : null}
-          {errMsg ? <p className="mb-4 text-sm text-red-600 dark:text-red-400">{errMsg}</p> : null}
-          {loading && !listError ? (
-            <div className="h-96 animate-pulse rounded-3xl bg-zinc-100 dark:bg-zinc-900" aria-hidden="true" />
-          ) : null}
-
-          {shown ? (
-            <AnimatePresence mode="wait">
-              <motion.div
-                key={shown.key}
-                initial={reduce ? false : { opacity: 0, y: 16 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={reduce ? { opacity: 0 } : { opacity: 0, y: -16 }}
-                transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
-                aria-busy={ready ? undefined : true}
-                className={`relative overflow-hidden rounded-2xl border-2 border-emerald-700/25 bg-[#fbfaf2] p-2 transition-opacity dark:border-emerald-400/20 dark:bg-zinc-900/60 ${
-                  ready ? "" : "opacity-50"
-                }`}
-              >
-                <StarField className="pointer-events-none absolute inset-0 size-full text-emerald-800/[0.05] dark:text-emerald-400/[0.06]" />
-                <div className="relative  px-2 py-4 sm:px-10 ">
-                  {segments.map((seg, si) => {
-                    const startsSurah = seg.items[0]?.ayah.numberInSurah === 1;
-                    const showBismillah =
-                      startsSurah && seg.surah?.number !== 1 && seg.surah?.number !== 9;
-                    return (
-                      <div key={seg.key} className={si > 0 ? "mt-10" : ""}>
-                        {seg.surah && startsSurah ? (
-                          <>
-                            {/* surah header cartouche */}
-                            <div className="flex items-center justify-center gap-3">
-                              <Star8 className="size-5 shrink-0 text-amber-500/70 dark:text-amber-300/60" />
-                              <div className="rounded-2xl border border-emerald-700/30 bg-emerald-50/70 px-6 py-2 dark:border-emerald-400/25 dark:bg-emerald-500/10">
-                                <span
-                                  lang="ar"
-                                  dir="rtl"
-                                  className="font-arabic text-3xl text-emerald-800 sm:text-4xl dark:text-emerald-300"
-                                >
-                                  {seg.surah.name}
-                                </span>
-                              </div>
-                              <Star8 className="size-5 shrink-0 text-amber-500/70 dark:text-amber-300/60" />
-                            </div>
-                            <p className={`mt-3 text-center text-sm ${mutedCls}`}>
-                              {seg.surah.englishName} ·{" "}
-                              {t.revelation[seg.surah.revelationType] ?? seg.surah.revelationType} ·{" "}
-                              {seg.surah.numberOfAyahs} {t.ayahs}
-                            </p>
-                          </>
-                        ) : seg.surah ? (
-                          // a surah carried over from the previous page
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={`${unit.mode}-${unit.n}`}
+              initial={reduce ? false : { opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={reduce ? { opacity: 0 } : { opacity: 0, y: -16 }}
+              transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
+              className="relative overflow-hidden rounded-2xl border-2 border-emerald-700/25 bg-[#fbfaf2] p-2 dark:border-emerald-400/20 dark:bg-zinc-900/60"
+            >
+              <StarField className="pointer-events-none absolute inset-0 size-full text-emerald-800/[0.05] dark:text-emerald-400/[0.06]" />
+              <div className="relative px-2 py-4 sm:px-10">
+                {segments.map((seg, si) => {
+                  const startsSurah = seg.items[0]?.ayah.ayah === 1;
+                  const showBismillah = startsSurah && seg.surah.n !== 1 && seg.surah.n !== 9;
+                  return (
+                    <div key={seg.key} className={si > 0 ? "mt-10" : ""}>
+                      {startsSurah ? (
+                        <>
+                          {/* surah header cartouche */}
                           <div className="flex items-center justify-center gap-3">
-                            <span className="h-px flex-1 bg-emerald-700/15 dark:bg-emerald-400/15" />
-                            <span lang="ar" dir="rtl" className={`font-arabic text-lg ${mutedCls}`}>
-                              {seg.surah.name}
-                              {si === 0 ? ` — ${t.continued}` : ""}
-                            </span>
-                            <span className="h-px flex-1 bg-emerald-700/15 dark:bg-emerald-400/15" />
+                            <Star8 className="size-5 shrink-0 text-amber-500/70 dark:text-amber-300/60" />
+                            <div className="rounded-2xl border border-emerald-700/30 bg-emerald-50/70 px-6 py-2 dark:border-emerald-400/25 dark:bg-emerald-500/10">
+                              <span
+                                lang="ar"
+                                dir="rtl"
+                                className="font-arabic text-3xl text-emerald-800 sm:text-4xl dark:text-emerald-300"
+                              >
+                                {seg.surah.arabic}
+                              </span>
+                            </div>
+                            <Star8 className="size-5 shrink-0 text-amber-500/70 dark:text-amber-300/60" />
                           </div>
-                        ) : null}
-
-                        {showBismillah ? (
-                          <p
-                            lang="ar"
-                            dir="rtl"
-                            className="mt-7 text-center font-arabic text-2xl text-emerald-900 sm:text-3xl dark:text-emerald-200"
-                          >
-                            {BISMILLAH}
+                          <p className={`mt-3 text-center text-sm ${mutedCls}`}>
+                            {seg.surah.translit} ·{" "}
+                            {t.revelation[seg.surah.revelation] ?? seg.surah.revelation} ·{" "}
+                            {seg.surah.ayahs} {t.ayahs}
                           </p>
-                        ) : null}
+                        </>
+                      ) : (
+                        // a surah carried over from the previous unit
+                        <div className="flex items-center justify-center gap-3">
+                          <span className="h-px flex-1 bg-emerald-700/15 dark:bg-emerald-400/15" />
+                          <span lang="ar" dir="rtl" className={`font-arabic text-lg ${mutedCls}`}>
+                            {seg.surah.arabic}
+                            {si === 0 ? ` — ${t.continued}` : ""}
+                          </span>
+                          <span className="h-px flex-1 bg-emerald-700/15 dark:bg-emerald-400/15" />
+                        </div>
+                      )}
 
-                        {/* flowing Uthmani text — each verse hoverable/tappable */}
-                        <div
+                      {showBismillah ? (
+                        <p
                           lang="ar"
                           dir="rtl"
-                          className="mt-7 text-right font-arabic text-zinc-900 dark:text-zinc-100"
-                          style={{ fontSize: `${1.7 * scale}rem`, lineHeight: 2.35 }}
+                          className="mt-7 text-center font-arabic text-2xl text-emerald-900 sm:text-3xl dark:text-emerald-200"
                         >
-                          {seg.items.map(({ ayah, i }) => {
-                            const text =
-                              ayah.numberInSurah === 1 && showBismillah
-                                ? stripLeadingBasmala(ayah.text)
-                                : ayah.text;
-                            const on = i === activeIdx || i === playingIdx;
-                            return (
-                              <span
-                                key={`${seg.key}-${ayah.numberInSurah}`}
-                                id={`ayah-${i}`}
-                                data-ayah={i}
-                                onMouseEnter={transMode === "hover" ? (e) => openTip(i, e) : undefined}
-                                onMouseLeave={transMode === "hover" ? scheduleTipClose : undefined}
-                                onClick={transMode !== "off" ? (e) => openTip(i, e) : undefined}
-                                className={`rounded-lg px-0.5 transition-colors ${
-                                  transMode !== "off" ? "cursor-pointer" : ""
-                                } ${
-                                  on
-                                    ? "bg-emerald-200/70 dark:bg-emerald-400/25"
-                                    : "hover:bg-emerald-100/60 dark:hover:bg-emerald-500/10"
-                                }`}
-                              >
-                                {text}
-                                <AyahMark n={ayah.numberInSurah} />{" "}
-                              </span>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    );
-                  })}
+                          {BISMILLAH}
+                        </p>
+                      ) : null}
 
-                  {shown.mode === "page" ? (
-                    <p className={`mt-8 text-center text-sm ${goldCls}`}>﴿ {toArabicNum(shown.unit)} ﴾</p>
-                  ) : null}
-                </div>
-              </motion.div>
-            </AnimatePresence>
-          ) : null}
+                      {/* flowing Uthmani text — each verse hoverable/tappable */}
+                      <div
+                        lang="ar"
+                        dir="rtl"
+                        className="mt-7 text-right font-arabic text-zinc-900 dark:text-zinc-100"
+                        style={{ fontSize: `${1.7 * scale}rem`, lineHeight: 2.35 }}
+                      >
+                        {seg.items.map(({ ayah, i }) => {
+                          const text =
+                            ayah.ayah === 1 && showBismillah
+                              ? stripLeadingBasmala(ayah.arabic)
+                              : ayah.arabic;
+                          const on = i === activeIdx || i === playingIdx;
+                          return (
+                            <span
+                              key={ayah.n}
+                              id={`ayah-${i}`}
+                              data-ayah={i}
+                              onMouseEnter={transMode === "hover" ? (e) => openTip(i, e) : undefined}
+                              onMouseLeave={transMode === "hover" ? scheduleTipClose : undefined}
+                              onClick={transMode !== "off" ? (e) => openTip(i, e) : undefined}
+                              className={`rounded-lg px-0.5 transition-colors ${
+                                transMode !== "off" ? "cursor-pointer" : ""
+                              } ${
+                                on
+                                  ? "bg-emerald-200/70 dark:bg-emerald-400/25"
+                                  : "hover:bg-emerald-100/60 dark:hover:bg-emerald-500/10"
+                              }`}
+                            >
+                              {text}
+                              <AyahMark n={ayah.ayah} />{" "}
+                            </span>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })}
+
+                {unit.mode === "page" ? (
+                  <p className={`mt-8 text-center text-sm ${goldCls}`}>﴿ {toArabicNum(unit.n)} ﴾</p>
+                ) : null}
+              </div>
+            </motion.div>
+          </AnimatePresence>
 
           {/* discoverability hint for the translation bubble */}
-          {shown && transMode !== "off" && !anchor ? (
+          {transMode !== "off" && !anchor ? (
             <p className={`mt-4 flex items-center justify-center gap-2 text-xs ${mutedCls}`}>
               <Icon icon="ph:hand-pointing" className="size-4" />
               {transMode === "hover" ? t.hoverHint : t.clickHint}
             </p>
           ) : null}
+
+          {/* The tooltip is the reading experience, but it only exists after a
+              pointer event — so the translation also ships as real text here,
+              where a crawler (and anyone who prefers a list) can read it. */}
+          <details className={`mt-6 rounded-2xl border ${lineCls} p-4`}>
+            <summary className="cursor-pointer text-sm font-semibold">
+              {d.quranBrowse.translationList}
+            </summary>
+            <ol className="mt-4 space-y-4">
+              {ayahs.map((a, i) => (
+                <li key={a.n} className="flex gap-3">
+                  <span className={`shrink-0 font-mono text-xs ${goldCls}`}>
+                    {a.surah}:{a.ayah}
+                  </span>
+                  <p
+                    lang={transIsRtl ? "ar" : transEdition.split(".")[0]}
+                    dir={transIsRtl ? "rtl" : "ltr"}
+                    className={`leading-relaxed ${mutedCls} ${
+                      transIsRtl ? "text-right font-arabic text-base" : "text-sm"
+                    }`}
+                  >
+                    {translationAt(i)}
+                  </p>
+                </li>
+              ))}
+            </ol>
+          </details>
         </div>
 
         {/* ---- desktop sidebar ---- */}
@@ -559,6 +522,8 @@ export default function QuranClient() {
           <ControlsPanel q={q} />
         </aside>
       </div>
+
+      {children}
 
       {/* keeps the page footer clear of the fixed mobile bar */}
       <div className="h-20 lg:hidden" aria-hidden="true" />
@@ -573,7 +538,6 @@ export default function QuranClient() {
           <button
             type="button"
             onClick={prevAyah}
-            disabled={!audioReady}
             aria-label={t.prevAyah}
             className={`size-9 shrink-0 ${iconBtnCls}`}
           >
@@ -582,16 +546,14 @@ export default function QuranClient() {
           <button
             type="button"
             onClick={togglePlay}
-            disabled={!audioReady}
             aria-label={isPlaying ? t.pause : t.playSurah}
-            className="grid size-11 shrink-0 place-items-center rounded-full bg-emerald-700 text-white shadow-lg shadow-emerald-700/25 disabled:opacity-50 dark:bg-emerald-400 dark:text-emerald-950"
+            className="grid size-11 shrink-0 place-items-center rounded-full bg-emerald-700 text-white shadow-lg shadow-emerald-700/25 dark:bg-emerald-400 dark:text-emerald-950"
           >
             <Icon icon={isPlaying ? "ph:pause-fill" : "ph:play-fill"} className="size-5" />
           </button>
           <button
             type="button"
             onClick={nextAyah}
-            disabled={!audioReady}
             aria-label={t.nextAyah}
             className={`size-9 shrink-0 ${iconBtnCls}`}
           >
@@ -601,14 +563,14 @@ export default function QuranClient() {
           <div className="min-w-0 flex-1 leading-tight">
             <p className="truncate text-xs font-semibold text-zinc-900 dark:text-zinc-100">
               <span lang="ar" dir="rtl" className="font-arabic">
-                {headerSurah?.name ?? ""}
+                {headerSurah?.arabic ?? ""}
               </span>
-              {playingIdx !== null ? <span className={goldCls}> · {labelFor(playingIdx)}</span> : null}
+              {playingIdx !== null ? (
+                <span className={goldCls}> · {labelFor(playingIdx)}</span>
+              ) : null}
             </p>
             <p className={`truncate text-[11px] ${mutedCls}`}>
-              {mode === "page"
-                ? `${t.pageOf(pageNumber, TOTAL_PAGES)}${currentJuz ? ` · ${t.juz(currentJuz)}` : ""}`
-                : (RECITERS.find((r) => r.id === reciter)?.name ?? "")}
+              {RECITERS.find((r) => r.id === reciter)?.name ?? ""}
             </p>
           </div>
 
@@ -662,7 +624,7 @@ export default function QuranClient() {
                   <Icon icon="ph:x" className="size-4" />
                 </button>
               </div>
-              <ControlsPanel q={q} />
+              <ControlsPanel q={q} onNavigate={() => setSheetOpen(false)} />
             </motion.div>
           </>
         ) : null}
@@ -677,7 +639,7 @@ export default function QuranClient() {
           lang={transIsRtl ? "ar" : transEdition.split(".")[0]}
           dir={transIsRtl ? "rtl" : "ltr"}
           playing={playingIdx === anchor.idx && isPlaying}
-          canPlay={!!audioReady}
+          canPlay={ayahs.length > 0}
           dismissible={transMode === "click"}
           playLabel={t.playVerse}
           closeLabel={t.close}
@@ -703,3 +665,4 @@ export default function QuranClient() {
     </ToolShell>
   );
 }
+

--- a/app/[locale]/quran/controls.tsx
+++ b/app/[locale]/quran/controls.tsx
@@ -1,52 +1,36 @@
 "use client";
 
 import { Icon } from "@iconify/react";
+import Link from "next/link";
 import { useState } from "react";
 import { brandCls, cardCls, goldCls, lineCls, mutedCls, Select } from "@/components/ui";
-import type { Dict } from "@/lib/i18n";
-import { type Surah, TOTAL_PAGES } from "@/lib/quran";
+import type { Dict, Locale } from "@/lib/i18n";
+import { JUZ, SURAHS, TOTAL_PAGES } from "@/lib/quran-meta";
+import {
+  type BrowseMode,
+  RECITERS,
+  TRANSLATIONS,
+  UNIT_TOTAL,
+  unitPath,
+} from "@/lib/quran-reader";
 
-/** A curated set of well-known reciters available on AlQuran.cloud. */
-export const RECITERS = [
-  { id: "ar.alafasy", name: "Mishary Alafasy" },
-  { id: "ar.husary", name: "Mahmoud Al-Husary" },
-  { id: "ar.abdurrahmaansudais", name: "Abdul Rahman Al-Sudais" },
-  { id: "ar.mahermuaiqly", name: "Maher Al-Muaiqly" },
-  { id: "ar.shaatree", name: "Abu Bakr Al-Shatri" },
-  { id: "ar.ahmedajamy", name: "Ahmed Al-Ajamy" },
-  { id: "ar.hudhaify", name: "Ali Al-Hudhaify" },
-  { id: "ar.abdulsamad", name: "Abdul Basit Abdul Samad" },
-];
-
-export const TRANSLATIONS = [
-  { id: "en.sahih", name: "Saheeh International · EN" },
-  { id: "en.pickthall", name: "Pickthall · EN" },
-  { id: "en.yusufali", name: "Yusuf Ali · EN" },
-  { id: "en.asad", name: "Muhammad Asad · EN" },
-  { id: "en.transliteration", name: "Transliteration" },
-  { id: "fr.hamidullah", name: "Hamidullah · FR" },
-  { id: "ar.muyassar", name: "التفسير الميسّر · AR" },
-];
-
-export const SPEEDS = [0.75, 1, 1.25, 1.5];
-
-export type BrowseMode = "surah" | "page";
 export type TransMode = "hover" | "click" | "off";
 export type RepeatMode = "off" | "ayah" | "surah";
 
-/** Everything the control surfaces need. The state itself lives in the page
- * client; both the desktop sidebar and the mobile sheet render from this one
- * object so the two never drift apart. */
+/** Everything the control surfaces need. The state lives in the reader; both
+ * the desktop sidebar and the mobile sheet render from this one object so the
+ * two never drift apart. */
 export type QuranUi = {
+  /** Reader chrome (reciter, speed, play…). */
   t: Dict["tools"]["quran"];
-  surahs: Surah[] | null;
+  /** Browse vocabulary (surah, juz, hizb, page…), shared with the SEO copy. */
+  b: Dict["quranBrowse"];
+  locale: Locale;
+  /** Which division is being read, and which one of it. */
   mode: BrowseMode;
+  n: number;
   setMode: (m: BrowseMode) => void;
-  surahNumber: number;
-  pageNumber: number;
-  goToSurah: (n: number) => void;
-  goToPage: (n: number) => void;
-  /** e.g. "Al-Baqara · Medinan · 286 ayahs" or "Page 3 of 604 · Juz 1". */
+  goTo: (mode: BrowseMode, n: number) => void;
   metaLine: string;
   verseLabel: string;
   reciter: string;
@@ -88,7 +72,9 @@ export const iconBtnCls = `grid place-items-center rounded-full border ${lineCls
 
 function SectionTitle({ icon, label }: { icon: string; label: string }) {
   return (
-    <p className={`mb-3 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] ${mutedCls}`}>
+    <p
+      className={`mb-3 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] ${mutedCls}`}
+    >
       <Icon icon={icon} className={`size-3.5 ${brandCls}`} />
       {label}
     </p>
@@ -109,21 +95,29 @@ function Segmented<T extends string>({
   value,
   onChange,
   options,
+  compact = false,
 }: {
   label: string;
   value: T;
   onChange: (v: T) => void;
   options: { value: T; label: string }[];
+  compact?: boolean;
 }) {
   return (
-    <div role="group" aria-label={label} className={`flex items-center rounded-full border p-0.5 ${lineCls}`}>
+    <div
+      role="group"
+      aria-label={label}
+      className={`flex items-center rounded-full border p-0.5 ${lineCls}`}
+    >
       {options.map((o) => (
         <button
           key={o.value}
           type="button"
           onClick={() => onChange(o.value)}
           aria-pressed={value === o.value}
-          className={`flex-1 rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+          className={`flex-1 rounded-full py-1.5 font-medium transition-colors ${
+            compact ? "px-2 text-[11px]" : "px-3 text-xs"
+          } ${
             value === o.value
               ? "bg-emerald-700 text-white dark:bg-emerald-400 dark:text-emerald-950"
               : `${mutedCls} hover:text-emerald-700 dark:hover:text-emerald-400`
@@ -137,23 +131,29 @@ function Segmented<T extends string>({
 }
 
 /** Page jump box: free typing while focused, committed on blur or Enter. */
-function PageInput({ q }: { q: QuranUi }) {
-  const [draft, setDraft] = useState(String(q.pageNumber));
+function PageInput({ q, onNavigate }: { q: QuranUi; onNavigate?: () => void }) {
+  const [draft, setDraft] = useState(String(q.n));
   // Re-sync when the page changes from elsewhere (arrows, mode switch).
-  const [seen, setSeen] = useState(q.pageNumber);
-  if (seen !== q.pageNumber) {
-    setSeen(q.pageNumber);
-    setDraft(String(q.pageNumber));
+  const [seen, setSeen] = useState(q.n);
+  if (seen !== q.n) {
+    setSeen(q.n);
+    setDraft(String(q.n));
   }
 
   const commit = () => {
     const n = Number(draft);
-    if (Number.isFinite(n) && n >= 1 && n <= TOTAL_PAGES) q.goToPage(n);
-    else setDraft(String(q.pageNumber));
+    if (Number.isFinite(n) && n >= 1 && n <= TOTAL_PAGES && n !== q.n) {
+      onNavigate?.();
+      q.goTo("page", n);
+    } else if (n !== q.n) {
+      setDraft(String(q.n));
+    }
   };
 
   return (
-    <div className={`flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-xl border ${lineCls} bg-white px-2 py-2 dark:bg-zinc-900`}>
+    <div
+      className={`flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-xl border ${lineCls} bg-white px-2 py-2 dark:bg-zinc-900`}
+    >
       <input
         type="number"
         inputMode="numeric"
@@ -176,7 +176,7 @@ function PageInput({ q }: { q: QuranUi }) {
   );
 }
 
-/** Continuous scrubber across the whole surah or page: the value is
+/** Continuous scrubber across the whole unit: the value is
  * `verseIndex + fractionOfThatVerse`, so one drag walks the recitation. */
 export function SeekBar({ q, className = "" }: { q: QuranUi; className?: string }) {
   const value = (q.playingIdx ?? 0) + (q.duration > 0 ? q.currentTime / q.duration : 0);
@@ -205,13 +205,14 @@ function ProgressRow({ q }: { q: QuranUi }) {
         {formatTime(q.currentTime)}
       </span>
       <SeekBar q={q} className="h-1.5 w-full" />
-      <span className={`min-w-8 text-[11px] font-semibold tabular-nums ${mutedCls}`}>{percent}%</span>
+      <span className={`min-w-8 text-[11px] font-semibold tabular-nums ${mutedCls}`}>
+        {percent}%
+      </span>
     </div>
   );
 }
 
-/** Prev / play / next, plus speed, repeat and mute. Shared by the desktop
- * sidebar and the mobile sheet. */
+/** Prev / play / next, plus speed, repeat and mute. */
 export function Transport({ q }: { q: QuranUi }) {
   const { t } = q;
   return (
@@ -262,8 +263,20 @@ export function Transport({ q }: { q: QuranUi }) {
           <button
             type="button"
             onClick={q.cycleRepeat}
-            title={q.repeatMode === "ayah" ? t.repeatAyah : q.repeatMode === "surah" ? t.repeatSurah : t.repeatOff}
-            aria-label={q.repeatMode === "ayah" ? t.repeatAyah : q.repeatMode === "surah" ? t.repeatSurah : t.repeatOff}
+            title={
+              q.repeatMode === "ayah"
+                ? t.repeatAyah
+                : q.repeatMode === "surah"
+                  ? t.repeatSurah
+                  : t.repeatOff
+            }
+            aria-label={
+              q.repeatMode === "ayah"
+                ? t.repeatAyah
+                : q.repeatMode === "surah"
+                  ? t.repeatSurah
+                  : t.repeatOff
+            }
             className={
               q.repeatMode !== "off"
                 ? "grid size-8 place-items-center rounded-full border border-emerald-600 bg-emerald-50 text-emerald-700 dark:border-emerald-400 dark:bg-emerald-500/10 dark:text-emerald-400"
@@ -279,7 +292,10 @@ export function Transport({ q }: { q: QuranUi }) {
             aria-label={q.isMuted ? t.unmute : t.mute}
             className={`size-8 ${iconBtnCls} ${q.isMuted ? "text-red-500 dark:text-red-400" : ""}`}
           >
-            <Icon icon={q.isMuted ? "ph:speaker-slash-fill" : "ph:speaker-high-fill"} className="size-4" />
+            <Icon
+              icon={q.isMuted ? "ph:speaker-slash-fill" : "ph:speaker-high-fill"}
+              className="size-4"
+            />
           </button>
         </div>
       </div>
@@ -287,61 +303,110 @@ export function Transport({ q }: { q: QuranUi }) {
   );
 }
 
-function NavigatorCard({ q }: { q: QuranUi }) {
-  const { t } = q;
+/** Prev / next stepper. Real <Link>s, so the neighbouring unit is a crawlable
+ * URL and not just an onClick. */
+function Stepper({
+  q,
+  onNavigate,
+  children,
+}: {
+  q: QuranUi;
+  onNavigate?: () => void;
+  children: React.ReactNode;
+}) {
+  const max = UNIT_TOTAL[q.mode];
+  const arrow = (dir: -1 | 1) => {
+    const n = q.n + dir;
+    const disabled = n < 1 || n > max;
+    const icon = dir === -1 ? "ph:caret-left" : "ph:caret-right";
+    const label = dir === -1 ? q.b.prev : q.b.next;
+    if (disabled) {
+      return (
+        <span aria-hidden="true" className={`size-10 shrink-0 opacity-40 ${iconBtnCls}`}>
+          <Icon icon={icon} className="size-4 rtl:rotate-180" />
+        </span>
+      );
+    }
+    return (
+      <Link
+        href={unitPath(q.locale, q.mode, n)}
+        onClick={onNavigate}
+        aria-label={label}
+        className={`size-10 shrink-0 ${iconBtnCls}`}
+      >
+        <Icon icon={icon} className="size-4 rtl:rotate-180" />
+      </Link>
+    );
+  };
+
+  return (
+    <div className="mt-3 flex items-center gap-2">
+      {arrow(-1)}
+      {children}
+      {arrow(1)}
+    </div>
+  );
+}
+
+function NavigatorCard({ q, onNavigate }: { q: QuranUi; onNavigate?: () => void }) {
+  const { b } = q;
+  const isAr = q.locale === "ar";
+
+  const pick = (n: number) => {
+    onNavigate?.();
+    q.goTo(q.mode, n);
+  };
+
   return (
     <section className={`${cardCls} p-4`}>
-      <SectionTitle icon="ph:compass" label={t.navigate} />
+      <SectionTitle icon="ph:compass" label={b.navigate} />
       <Segmented
-        label={t.browseBy}
+        compact
+        label={b.browseBy}
         value={q.mode}
-        onChange={q.setMode}
+        onChange={(m) => {
+          onNavigate?.();
+          q.setMode(m);
+        }}
         options={[
-          { value: "surah", label: t.bySurah },
-          { value: "page", label: t.byPage },
+          { value: "surah" as const, label: b.bySurah },
+          { value: "juz" as const, label: b.byJuz },
+          { value: "hizb" as const, label: b.byHizb },
+          { value: "page" as const, label: b.byPage },
         ]}
       />
 
-      <div className="mt-3 flex items-center gap-2">
-        <button
-          type="button"
-          onClick={() => (q.mode === "surah" ? q.goToSurah(q.surahNumber - 1) : q.goToPage(q.pageNumber - 1))}
-          disabled={q.mode === "surah" ? q.surahNumber <= 1 : q.pageNumber <= 1}
-          aria-label={q.mode === "surah" ? t.prev : t.prevPage}
-          className={`size-10 shrink-0 ${iconBtnCls}`}
-        >
-          <Icon icon="ph:caret-left" className="size-4 rtl:rotate-180" />
-        </button>
-
-        {q.mode === "surah" ? (
+      <Stepper q={q} onNavigate={onNavigate}>
+        {q.mode === "page" ? (
+          <PageInput q={q} onNavigate={onNavigate} />
+        ) : (
           <div className="min-w-0 flex-1">
             <Select
-              value={q.surahNumber}
-              onChange={(e) => q.goToSurah(Number(e.target.value))}
-              disabled={!q.surahs}
-              aria-label={t.surah}
+              value={q.n}
+              onChange={(e) => pick(Number(e.target.value))}
+              aria-label={q.mode === "surah" ? b.surah : q.mode === "juz" ? b.juz : b.hizb}
             >
-              {(q.surahs ?? []).map((s) => (
-                <option key={s.number} value={s.number}>
-                  {s.number}. {s.englishName}
-                </option>
-              ))}
+              {q.mode === "surah"
+                ? SURAHS.map((s) => (
+                    <option key={s.n} value={s.n}>
+                      {s.n}. {isAr ? s.arabic.replace(/^سُورَةُ\s*/, "") : s.translit}
+                    </option>
+                  ))
+                : q.mode === "juz"
+                  ? JUZ.map((j) => (
+                      <option key={j.n} value={j.n}>
+                        {b.juz} {j.n} · {isAr ? j.arabic : j.translit}
+                      </option>
+                    ))
+                  : Array.from({ length: UNIT_TOTAL.hizb }, (_, i) => i + 1).map((n) => (
+                      <option key={n} value={n}>
+                        {b.hizb} {n}
+                      </option>
+                    ))}
             </Select>
           </div>
-        ) : (
-          <PageInput q={q} />
         )}
-
-        <button
-          type="button"
-          onClick={() => (q.mode === "surah" ? q.goToSurah(q.surahNumber + 1) : q.goToPage(q.pageNumber + 1))}
-          disabled={q.mode === "surah" ? q.surahNumber >= 114 : q.pageNumber >= TOTAL_PAGES}
-          aria-label={q.mode === "surah" ? t.next : t.nextPage}
-          className={`size-10 shrink-0 ${iconBtnCls}`}
-        >
-          <Icon icon="ph:caret-right" className="size-4 rtl:rotate-180" />
-        </button>
-      </div>
+      </Stepper>
 
       <p className={`mt-3 text-xs ${mutedCls}`}>{q.metaLine}</p>
     </section>
@@ -398,9 +463,9 @@ function ReadingCard({ q }: { q: QuranUi }) {
         value={q.transMode}
         onChange={q.setTransMode}
         options={[
-          { value: "hover", label: t.modeHover },
-          { value: "click", label: t.modeClick },
-          { value: "off", label: t.modeOff },
+          { value: "hover" as const, label: t.modeHover },
+          { value: "click" as const, label: t.modeClick },
+          { value: "off" as const, label: t.modeOff },
         ]}
       />
 
@@ -432,10 +497,10 @@ function ReadingCard({ q }: { q: QuranUi }) {
 
 /** The full control stack — the desktop sidebar renders it as-is, the mobile
  * sheet renders the same thing inside a bottom drawer. */
-export function ControlsPanel({ q }: { q: QuranUi }) {
+export function ControlsPanel({ q, onNavigate }: { q: QuranUi; onNavigate?: () => void }) {
   return (
     <div className="flex flex-col gap-4">
-      <NavigatorCard q={q} />
+      <NavigatorCard q={q} onNavigate={onNavigate} />
       <RecitationCard q={q} />
       <ReadingCard q={q} />
     </div>

--- a/app/[locale]/quran/hizb/[hizb]/page.tsx
+++ b/app/[locale]/quran/hizb/[hizb]/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { RelatedUnits } from "@/components/quran-browse";
+import { locales, type Locale } from "@/lib/i18n";
+import { HIZB, hizbByNumber } from "@/lib/quran-meta";
+import { buildQuranPage } from "@/lib/quran-page";
+import { readingJsonLd } from "@/lib/quran-seo";
+import { JsonLd, pageMeta } from "@/lib/seo";
+import Client from "../../client";
+
+type Props = { params: Promise<{ locale: Locale; hizb: string }> };
+
+export function generateStaticParams() {
+  return locales.flatMap((locale) => HIZB.map((h) => ({ locale, hizb: String(h.n) })));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale, hizb } = await params;
+  if (!hizbByNumber(Number(hizb))) return {};
+  const p = await buildQuranPage(locale, "hizb", Number(hizb));
+  return pageMeta(locale, p.path, p.title, p.description);
+}
+
+export default async function Page({ params }: Props) {
+  const { locale, hizb } = await params;
+  const n = Number(hizb);
+  if (!hizbByNumber(n)) notFound();
+  const p = await buildQuranPage(locale, "hizb", n);
+
+  return (
+    <>
+      <JsonLd
+        data={readingJsonLd({
+          locale,
+          path: p.path,
+          name: p.title,
+          description: p.description,
+          crumb: p.crumb,
+          position: n,
+        })}
+      />
+      <Client unit={p.unit} heading={p.heading}>
+        <RelatedUnits locale={locale} links={p.related} />
+      </Client>
+    </>
+  );
+}

--- a/app/[locale]/quran/juz/[juz]/page.tsx
+++ b/app/[locale]/quran/juz/[juz]/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { RelatedUnits } from "@/components/quran-browse";
+import { locales, type Locale } from "@/lib/i18n";
+import { JUZ, juzByNumber } from "@/lib/quran-meta";
+import { buildQuranPage } from "@/lib/quran-page";
+import { readingJsonLd } from "@/lib/quran-seo";
+import { JsonLd, pageMeta } from "@/lib/seo";
+import Client from "../../client";
+
+type Props = { params: Promise<{ locale: Locale; juz: string }> };
+
+export function generateStaticParams() {
+  return locales.flatMap((locale) => JUZ.map((j) => ({ locale, juz: String(j.n) })));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale, juz } = await params;
+  if (!juzByNumber(Number(juz))) return {};
+  const p = await buildQuranPage(locale, "juz", Number(juz));
+  return pageMeta(locale, p.path, p.title, p.description);
+}
+
+export default async function Page({ params }: Props) {
+  const { locale, juz } = await params;
+  const n = Number(juz);
+  if (!juzByNumber(n)) notFound();
+  const p = await buildQuranPage(locale, "juz", n);
+
+  return (
+    <>
+      <JsonLd
+        data={readingJsonLd({
+          locale,
+          path: p.path,
+          name: p.title,
+          description: p.description,
+          crumb: p.crumb,
+          position: n,
+        })}
+      />
+      <Client unit={p.unit} heading={p.heading}>
+        <RelatedUnits locale={locale} links={p.related} />
+      </Client>
+    </>
+  );
+}

--- a/app/[locale]/quran/page.tsx
+++ b/app/[locale]/quran/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next";
-import type { Locale } from "@/lib/i18n";
-import { ToolJsonLd, toolMetadata } from "@/lib/tool-page";
+import { QuranDirectory } from "@/components/quran-browse";
+import { getDict, type Locale } from "@/lib/i18n";
+import { buildQuranPage } from "@/lib/quran-page";
+import { quranHubJsonLd } from "@/lib/quran-seo";
+import { JsonLd } from "@/lib/seo";
+import { toolMetadata } from "@/lib/tool-page";
 import Client from "./client";
 
 type Props = { params: Promise<{ locale: Locale }> };
@@ -12,10 +16,22 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function Page({ params }: Props) {
   const { locale } = await params;
+  const d = getDict(locale);
+  // The hub opens on Al-Fatiha, but keeps the tool's own title and intro —
+  // it is the Quran landing page, not a surah page.
+  const p = await buildQuranPage(locale, "surah", 1);
+
   return (
     <>
-      <ToolJsonLd locale={locale} toolKey="quran" />
-      <Client />
+      {/* Book + ItemList — the machine-readable map of every surah and juz
+          route, so the deeper pages are discoverable from the hub alone. */}
+      <JsonLd data={quranHubJsonLd(locale)} />
+      <Client
+        unit={p.unit}
+        heading={{ title: d.tools.quran.title, side: d.tools.quran.side, intro: d.tools.quran.intro }}
+      >
+        <QuranDirectory locale={locale} />
+      </Client>
     </>
   );
 }

--- a/app/[locale]/quran/page/[page]/page.tsx
+++ b/app/[locale]/quran/page/[page]/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { RelatedUnits } from "@/components/quran-browse";
+import { locales, type Locale } from "@/lib/i18n";
+import { TOTAL_PAGES } from "@/lib/quran-meta";
+import { buildQuranPage } from "@/lib/quran-page";
+import { readingJsonLd } from "@/lib/quran-seo";
+import { JsonLd, pageMeta } from "@/lib/seo";
+import Client from "../../client";
+
+type Props = { params: Promise<{ locale: Locale; page: string }> };
+
+const valid = (n: number) => Number.isInteger(n) && n >= 1 && n <= TOTAL_PAGES;
+
+export function generateStaticParams() {
+  return locales.flatMap((locale) =>
+    Array.from({ length: TOTAL_PAGES }, (_, i) => ({ locale, page: String(i + 1) })),
+  );
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale, page } = await params;
+  if (!valid(Number(page))) return {};
+  const p = await buildQuranPage(locale, "page", Number(page));
+  return pageMeta(locale, p.path, p.title, p.description);
+}
+
+export default async function Page({ params }: Props) {
+  const { locale, page } = await params;
+  const n = Number(page);
+  if (!valid(n)) notFound();
+  const p = await buildQuranPage(locale, "page", n);
+
+  return (
+    <>
+      <JsonLd
+        data={readingJsonLd({
+          locale,
+          path: p.path,
+          name: p.title,
+          description: p.description,
+          crumb: p.crumb,
+          position: n,
+        })}
+      />
+      <Client unit={p.unit} heading={p.heading}>
+        <RelatedUnits locale={locale} links={p.related} />
+      </Client>
+    </>
+  );
+}

--- a/app/[locale]/quran/surah/[slug]/page.tsx
+++ b/app/[locale]/quran/surah/[slug]/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { RelatedUnits } from "@/components/quran-browse";
+import { locales, type Locale } from "@/lib/i18n";
+import { SURAHS, surahBySlug } from "@/lib/quran-meta";
+import { buildQuranPage } from "@/lib/quran-page";
+import { readingJsonLd } from "@/lib/quran-seo";
+import { JsonLd, pageMeta } from "@/lib/seo";
+import Client from "../../client";
+
+type Props = { params: Promise<{ locale: Locale; slug: string }> };
+
+export function generateStaticParams() {
+  return locales.flatMap((locale) => SURAHS.map((s) => ({ locale, slug: s.slug })));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale, slug } = await params;
+  const s = surahBySlug(slug);
+  if (!s) return {};
+  const p = await buildQuranPage(locale, "surah", s.n);
+  return pageMeta(locale, p.path, p.title, p.description);
+}
+
+export default async function Page({ params }: Props) {
+  const { locale, slug } = await params;
+  const s = surahBySlug(slug);
+  if (!s) notFound();
+  const p = await buildQuranPage(locale, "surah", s.n);
+
+  return (
+    <>
+      <JsonLd
+        data={readingJsonLd({
+          locale,
+          path: p.path,
+          name: p.title,
+          description: p.description,
+          crumb: p.crumb,
+          isChapter: true,
+          position: s.n,
+        })}
+      />
+      <Client unit={p.unit} heading={p.heading}>
+        <RelatedUnits locale={locale} links={p.related} />
+      </Client>
+    </>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,24 +1,40 @@
 import type { MetadataRoute } from "next";
 import { localePath, locales } from "@/lib/i18n";
-import { SITE_URL } from "@/lib/site";
+import { QURAN_PATH, quranPaths } from "@/lib/quran-seo";
 import { ABOUT_PATH, TOOL_PATHS } from "@/lib/seo";
+import { SITE_URL } from "@/lib/site";
 
 export const dynamic = "force-static";
 
+/** next.config sets `trailingSlash: true`, so /en/zakat serves a redirect and
+ * /en/zakat/ is the canonical. The sitemap has to list the canonical form —
+ * otherwise every URL Google fetches from it bounces through a 308. */
+const abs = (locale: (typeof locales)[number], path: string) =>
+  `${SITE_URL}${localePath(locale, path)}/`;
+
 export default function sitemap(): MetadataRoute.Sitemap {
-  const paths = ["", ABOUT_PATH, ...Object.values(TOOL_PATHS)];
   const lastModified = new Date();
 
-  return paths.flatMap((path) =>
+  // The Quran hub is listed by quranPaths() with its own priority, so it is
+  // dropped here to avoid a duplicate <url> entry.
+  const pages: { path: string; priority: number }[] = [
+    { path: "", priority: 1 },
+    { path: ABOUT_PATH, priority: 0.7 },
+    ...Object.values(TOOL_PATHS)
+      .filter((p) => p !== QURAN_PATH)
+      .map((path) => ({ path, priority: 0.8 })),
+    // ~1,600 URLs: 114 surahs, 30 juz, 60 hizb and all 604 mushaf pages.
+    ...quranPaths(),
+  ];
+
+  return pages.flatMap(({ path, priority }) =>
     locales.map((locale) => ({
-      url: `${SITE_URL}${localePath(locale, path)}`,
+      url: abs(locale, path),
       lastModified,
       changeFrequency: "monthly" as const,
-      priority: path === "" ? 1 : 0.8,
+      priority,
       alternates: {
-        languages: Object.fromEntries(
-          locales.map((l) => [l, `${SITE_URL}${localePath(l, path)}`]),
-        ),
+        languages: Object.fromEntries(locales.map((l) => [l, abs(l, path)])),
       },
     })),
   );

--- a/components/quran-browse.tsx
+++ b/components/quran-browse.tsx
@@ -1,0 +1,202 @@
+/** Server-rendered link indexes for the Quran routes.
+ *
+ * The reading experience itself is the interactive reader; these are the
+ * crawl paths into it. Deliberately server-only — every link must exist in
+ * the HTML a crawler receives, and none of this ships JavaScript. */
+
+import Link from "next/link";
+import { goldCls, lineCls, mutedCls, Star8 } from "@/components/ui";
+import { getDict, localePath, type Locale } from "@/lib/i18n";
+import { HIZB, JUZ, SURAHS, TOTAL_PAGES } from "@/lib/quran-meta";
+import { hizbPath, juzName, juzPath, mushafPath, surahName, surahPath } from "@/lib/quran-seo";
+
+/** The same passage seen as juz, hizb, mushaf page and surah. Real links, so
+ * the four views of the Quran are reachable from one another. */
+export function RelatedUnits({
+  locale,
+  links,
+}: {
+  locale: Locale;
+  links: { href: string; label: string }[];
+}) {
+  if (links.length === 0) return null;
+  const b = getDict(locale).quranBrowse;
+  return (
+    <nav className="mt-10" aria-label={b.alsoIn}>
+      <h2 className="flex items-center gap-3 font-display text-lg">
+        <Star8 className={`size-4 shrink-0 ${goldCls}`} />
+        {b.alsoIn}
+      </h2>
+      <ul className="mt-4 flex flex-wrap gap-2">
+        {links.map((l) => (
+          <li key={l.href}>
+            <Link
+              href={l.href}
+              className={`inline-flex items-center gap-2 rounded-full border ${lineCls} px-4 py-2 text-sm transition-colors hover:border-emerald-600 hover:text-emerald-700 dark:hover:border-emerald-400 dark:hover:text-emerald-400`}
+            >
+              {l.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+// ---------------------------------------------------------------- indexes
+
+function IndexHeading({ title, body }: { title: string; body: string }) {
+  return (
+    <>
+      <h2 className="flex items-center gap-3 font-display text-2xl sm:text-3xl">
+        <Star8 className={`size-5 shrink-0 ${goldCls}`} />
+        {title}
+      </h2>
+      <p className={`mt-3 max-w-2xl leading-relaxed ${mutedCls}`}>{body}</p>
+    </>
+  );
+}
+
+/** All 114 surahs. This is the crawl path to every surah route, and it is
+ * genuinely the fastest way for a reader to find one too. */
+export function SurahIndex({ locale }: { locale: Locale }) {
+  const b = getDict(locale).quranBrowse;
+  const isAr = locale === "ar";
+  return (
+    <section id="surahs" className="scroll-mt-20">
+      <IndexHeading title={b.hubSurahsTitle} body={b.hubSurahsP} />
+      <ul className="mt-8 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {SURAHS.map((s) => (
+          <li key={s.slug}>
+            <Link
+              href={localePath(locale, surahPath(s.slug))}
+              className={`group flex h-full items-center gap-3 rounded-2xl border ${lineCls} bg-white px-3.5 py-3 transition-[transform,border-color] duration-300 hover:-translate-y-0.5 hover:border-emerald-500/60 dark:bg-zinc-900/60 dark:hover:border-emerald-400/50`}
+            >
+              <span
+                className={`grid size-9 shrink-0 place-items-center rounded-full border border-emerald-700/20 font-mono text-xs font-semibold ${goldCls} dark:border-emerald-400/20`}
+              >
+                {s.n}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-semibold">
+                  {surahName(locale, s)}
+                </span>
+                <span className={`block truncate text-xs ${mutedCls}`}>
+                  {isAr ? b.ayahCount(s.ayahs) : `${s.meaning} · ${b.ayahCount(s.ayahs)}`}
+                </span>
+              </span>
+              {isAr ? null : (
+                <span lang="ar" dir="rtl" className="shrink-0 font-arabic text-lg">
+                  {s.arabic.replace(/^سُورَةُ\s*/, "")}
+                </span>
+              )}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export function JuzIndex({ locale }: { locale: Locale }) {
+  const b = getDict(locale).quranBrowse;
+  const isAr = locale === "ar";
+  return (
+    <section id="juz" className="mt-16 scroll-mt-20 sm:mt-20">
+      <IndexHeading title={b.hubJuzTitle} body={b.hubJuzP} />
+      <ul className="mt-8 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {JUZ.map((j) => (
+          <li key={j.n}>
+            <Link
+              href={localePath(locale, juzPath(j.n))}
+              className={`flex h-full items-center gap-3 rounded-2xl border ${lineCls} bg-white px-3.5 py-3 transition-colors hover:border-emerald-500/60 dark:bg-zinc-900/60 dark:hover:border-emerald-400/50`}
+            >
+              <span
+                className={`grid size-9 shrink-0 place-items-center rounded-full border border-emerald-700/20 font-mono text-xs font-semibold ${goldCls} dark:border-emerald-400/20`}
+              >
+                {j.n}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-semibold">
+                  {b.juz} {j.n} · {juzName(locale, j.n)}
+                </span>
+                <span className={`block truncate text-xs ${mutedCls}`}>
+                  {b.startsAt} {surahName(locale, SURAHS[j.start[0] - 1])} {j.start[0]}:{j.start[1]}
+                </span>
+              </span>
+              {isAr ? null : (
+                <span lang="ar" dir="rtl" className={`shrink-0 font-arabic text-lg ${goldCls}`}>
+                  {j.arabic}
+                </span>
+              )}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export function HizbIndex({ locale }: { locale: Locale }) {
+  const b = getDict(locale).quranBrowse;
+  return (
+    <section id="hizb" className="mt-16 scroll-mt-20 sm:mt-20">
+      <IndexHeading title={b.hubHizbTitle} body={b.hubHizbP} />
+      <ul className="mt-8 flex flex-wrap gap-2">
+        {HIZB.map((h) => (
+          <li key={h.n}>
+            <Link
+              href={localePath(locale, hizbPath(h.n))}
+              className={`inline-flex items-center gap-2 rounded-full border ${lineCls} px-4 py-2 text-sm transition-colors hover:border-emerald-600 hover:text-emerald-700 dark:hover:border-emerald-400 dark:hover:text-emerald-400`}
+            >
+              <span className="font-semibold">
+                {b.hizb} {h.n}
+              </span>
+              <span className={`font-mono text-xs ${mutedCls}`}>
+                {h.start[0]}:{h.start[1]}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+/** 604 links, collapsed behind a <details> — still in the HTML, so every
+ * mushaf page is one hop from the hub without swamping the layout. */
+export function PageIndex({ locale }: { locale: Locale }) {
+  const b = getDict(locale).quranBrowse;
+  return (
+    <section id="pages" className="mt-16 scroll-mt-20 sm:mt-20">
+      <IndexHeading title={b.hubPagesTitle} body={b.hubPagesP} />
+      <details className={`mt-8 rounded-2xl border ${lineCls} p-4`}>
+        <summary className="cursor-pointer text-sm font-semibold">{b.showAllPages}</summary>
+        <ul className="mt-4 grid grid-cols-[repeat(auto-fill,minmax(3.25rem,1fr))] gap-1.5">
+          {Array.from({ length: TOTAL_PAGES }, (_, i) => i + 1).map((n) => (
+            <li key={n}>
+              <Link
+                href={localePath(locale, mushafPath(n))}
+                className={`block rounded-lg border ${lineCls} py-1.5 text-center font-mono text-xs transition-colors hover:border-emerald-600 hover:text-emerald-700 dark:hover:border-emerald-400 dark:hover:text-emerald-400`}
+              >
+                {n}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </details>
+    </section>
+  );
+}
+
+/** Everything the hub renders below the interactive reader. */
+export function QuranDirectory({ locale }: { locale: Locale }) {
+  return (
+    <div className="mt-20">
+      <SurahIndex locale={locale} />
+      <JuzIndex locale={locale} />
+      <HizbIndex locale={locale} />
+      <PageIndex locale={locale} />
+    </div>
+  );
+}

--- a/lib/arabic.ts
+++ b/lib/arabic.ts
@@ -1,0 +1,30 @@
+/** Arabic text helpers shared by the reader and the prerendered routes.
+ *
+ * The character class matters more than it looks. Writing it with literal
+ * glyphs — `[ؐ-ًؚ-ٰٟۖ-ۭ]` — reads as the range U+0610–U+064B, which swallows
+ * every Arabic *letter* (U+0620–U+064A) along with the marks, so stripping
+ * "بِسْمِ" returned an empty string instead of "بسم". Spelled out in escapes,
+ * the ranges are unambiguous and only combining marks are removed. */
+
+const HARAKAT = /[\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06ED\u08D3-\u08FF]/g;
+/** Some ayah strings arrive with a byte-order mark or a tatweel. */
+const NOISE = /[\uFEFF\u0640]/g;
+
+/** Undecorated Arabic: no harakat, no BOM — what a reader would type into a
+ * search box, and what belongs in a meta description. */
+export function bareArabic(text: string): string {
+  return text.replace(NOISE, "").replace(HARAKAT, "").replace(/\s+/g, " ").trim();
+}
+
+/** Strip the invisible BOM without touching the vowel marks. */
+export function cleanAyah(text: string): string {
+  return text.replace(/\uFEFF/g, "");
+}
+
+/** Outside Al-Fatiha the Uthmani text prefixes the basmala to verse 1. Drop
+ * it so it can be shown as its own ornamental line instead of being read
+ * twice. */
+export function stripLeadingBasmala(text: string): string {
+  const words = cleanAyah(text).trim().split(/\s+/);
+  return bareArabic(words[0] ?? "") === "بسم" ? words.slice(4).join(" ") : text;
+}

--- a/lib/quran-build.ts
+++ b/lib/quran-build.ts
@@ -1,0 +1,141 @@
+/** The whole Quran, loaded once at build time.
+ *
+ * The site is a static export, so every surah / juz / hizb / page route is
+ * rendered to HTML during `next build`. Fetching per route would mean ~1,600
+ * API calls; instead the complete text comes down in one request per edition
+ * and every route slices the same in-memory copy. */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { cleanAyah } from "./arabic";
+import { getDict, type Locale } from "./i18n";
+import { TOTAL_AYAHS } from "./quran-meta";
+
+const API = "https://api.alquran.cloud/v1";
+const ARABIC_EDITION = "quran-uthmani";
+/** Filled by `npm run prebuild` (scripts/fetch-quran.mjs). */
+const CACHE_DIR = join(process.cwd(), ".quran-cache");
+
+export type BuiltAyah = {
+  /** Global ayah number, 1–6236 — also the recitation file name. */
+  n: number;
+  /** Surah number, 1–114. */
+  surah: number;
+  /** Ayah number within its surah. */
+  ayah: number;
+  page: number;
+  juz: number;
+  /** Hizb, 1–60 (the API reports quarters, 1–240). */
+  hizb: number;
+  arabic: string;
+  translation: string;
+};
+
+export type QuranText = {
+  ayahs: BuiltAyah[];
+  /** Which translation edition the `translation` field holds. */
+  edition: string;
+  bySurah: Map<number, BuiltAyah[]>;
+  byJuz: Map<number, BuiltAyah[]>;
+  byHizb: Map<number, BuiltAyah[]>;
+  byPage: Map<number, BuiltAyah[]>;
+};
+
+type ApiAyah = {
+  number: number;
+  numberInSurah: number;
+  text: string;
+  page: number;
+  juz: number;
+  hizbQuarter: number;
+};
+type ApiQuran = { data: { surahs: { number: number; ayahs: ApiAyah[] }[] } };
+
+function flatten(json: ApiQuran): ApiAyah[] {
+  return json.data.surahs.flatMap((s) =>
+    s.ayahs.map((a) => ({ ...a, surahNumber: s.number })),
+  ) as ApiAyah[];
+}
+
+/** Prefer the on-disk cache: `next build` runs ~11 worker processes, and
+ * having each of them pull 14 MB over the network is both slow and enough
+ * concurrent load to get the build refused. The network path stays as a
+ * fallback so a bare `next build` still works. */
+async function loadEdition(edition: string): Promise<ApiAyah[] | null> {
+  try {
+    const raw = await readFile(join(CACHE_DIR, `${edition}.json`), "utf8");
+    return flatten(JSON.parse(raw) as ApiQuran);
+  } catch {
+    // not cached — fall through to the API
+  }
+  try {
+    const res = await fetch(`${API}/quran/${edition}`, { cache: "force-cache" });
+    if (!res.ok) return null;
+    return flatten((await res.json()) as ApiQuran);
+  } catch {
+    return null;
+  }
+}
+
+function group<K>(ayahs: BuiltAyah[], key: (a: BuiltAyah) => K): Map<K, BuiltAyah[]> {
+  const map = new Map<K, BuiltAyah[]>();
+  for (const a of ayahs) {
+    const k = key(a);
+    const bucket = map.get(k);
+    if (bucket) bucket.push(a);
+    else map.set(k, [a]);
+  }
+  return map;
+}
+
+const cache = new Map<Locale, Promise<QuranText>>();
+
+async function build(locale: Locale): Promise<QuranText> {
+  const edition = getDict(locale).tools.quran.translationEdition;
+  const [arabic, translated] = await Promise.all([
+    loadEdition(ARABIC_EDITION),
+    loadEdition(edition),
+  ]);
+
+  // The Arabic text is the page. Without it there is nothing worth publishing,
+  // and shipping ~1,600 empty pages would be far worse than a failed build.
+  if (!arabic || arabic.length !== TOTAL_AYAHS) {
+    throw new Error(
+      `Quran build data: could not load "${ARABIC_EDITION}". The Quran routes are ` +
+        `prerendered, so the build needs .quran-cache/ populated — run ` +
+        `"node scripts/fetch-quran.mjs" (npm does this for you as prebuild).`,
+    );
+  }
+  // A missing translation is survivable — the Arabic still stands on its own.
+  const trans = translated?.length === TOTAL_AYAHS ? translated : null;
+
+  const ayahs: BuiltAyah[] = arabic.map((a, i) => ({
+    n: a.number,
+    surah: (a as ApiAyah & { surahNumber: number }).surahNumber,
+    ayah: a.numberInSurah,
+    page: a.page,
+    juz: a.juz,
+    hizb: Math.floor((a.hizbQuarter - 1) / 4) + 1,
+    arabic: cleanAyah(a.text),
+    translation: cleanAyah(trans?.[i]?.text ?? ""),
+  }));
+
+  return {
+    ayahs,
+    edition,
+    bySurah: group(ayahs, (a) => a.surah),
+    byJuz: group(ayahs, (a) => a.juz),
+    byHizb: group(ayahs, (a) => a.hizb),
+    byPage: group(ayahs, (a) => a.page),
+  };
+}
+
+/** Memoized per locale — one network round trip per edition, per build. */
+export function quranText(locale: Locale): Promise<QuranText> {
+  const hit = cache.get(locale);
+  if (hit) return hit;
+  const pending = build(locale);
+  cache.set(locale, pending);
+  return pending;
+}
+

--- a/lib/quran-meta.ts
+++ b/lib/quran-meta.ts
@@ -1,0 +1,258 @@
+/** Structural metadata for the Quran — the 114 surahs, 30 juz and 60 hizb.
+ *
+ * Hardcoded on purpose. These values never change, and baking them in means
+ * URLs, titles and navigation don't depend on a third-party API being up or
+ * on its transliteration spelling ("Al-Faatiha" vs the "al-fatihah" people
+ * actually search for). The verse text still comes from the API at build
+ * time; only the skeleton lives here. */
+
+export type SurahMeta = {
+  n: number;
+  /** URL slug — the standard transliteration, e.g. "al-kahf". */
+  slug: string;
+  translit: string;
+  arabic: string;
+  meaning: string;
+  revelation: "Meccan" | "Medinan";
+  ayahs: number;
+  /** Mushaf page this surah opens on. */
+  page: number;
+  /** Juz this surah opens in. */
+  juz: number;
+};
+
+export type JuzMeta = {
+  n: number;
+  arabic: string;
+  translit: string;
+  /** [surah, ayah] this juz opens at. */
+  start: [number, number];
+};
+
+export type HizbMeta = { n: number; juz: number; start: [number, number] };
+
+export const TOTAL_SURAHS = 114;
+export const TOTAL_JUZ = 30;
+export const TOTAL_HIZB = 60;
+export const TOTAL_PAGES = 604;
+export const TOTAL_AYAHS = 6236;
+
+export const SURAHS: SurahMeta[] = [
+  { n: 1, slug: "al-fatihah", translit: "Al-Fatihah", arabic: "سُورَةُ ٱلْفَاتِحَةِ", meaning: "The Opening", revelation: "Meccan", ayahs: 7, page: 1, juz: 1 },
+  { n: 2, slug: "al-baqarah", translit: "Al-Baqarah", arabic: "سُورَةُ البَقَرَةِ", meaning: "The Cow", revelation: "Medinan", ayahs: 286, page: 2, juz: 1 },
+  { n: 3, slug: "ali-imran", translit: "Ali 'Imran", arabic: "سُورَةُ آلِ عِمۡرَانَ", meaning: "The Family of Imraan", revelation: "Medinan", ayahs: 200, page: 50, juz: 3 },
+  { n: 4, slug: "an-nisa", translit: "An-Nisa", arabic: "سُورَةُ النِّسَاءِ", meaning: "The Women", revelation: "Medinan", ayahs: 176, page: 77, juz: 4 },
+  { n: 5, slug: "al-maidah", translit: "Al-Maidah", arabic: "سُورَةُ المَائـِدَةِ", meaning: "The Table", revelation: "Medinan", ayahs: 120, page: 106, juz: 6 },
+  { n: 6, slug: "al-anam", translit: "Al-Anam", arabic: "سُورَةُ الأَنۡعَامِ", meaning: "The Cattle", revelation: "Meccan", ayahs: 165, page: 128, juz: 7 },
+  { n: 7, slug: "al-araf", translit: "Al-Araf", arabic: "سُورَةُ الأَعۡرَافِ", meaning: "The Heights", revelation: "Meccan", ayahs: 206, page: 151, juz: 8 },
+  { n: 8, slug: "al-anfal", translit: "Al-Anfal", arabic: "سُورَةُ الأَنفَالِ", meaning: "The Spoils of War", revelation: "Medinan", ayahs: 75, page: 177, juz: 9 },
+  { n: 9, slug: "at-tawbah", translit: "At-Tawbah", arabic: "سُورَةُ التَّوۡبَةِ", meaning: "The Repentance", revelation: "Medinan", ayahs: 129, page: 187, juz: 10 },
+  { n: 10, slug: "yunus", translit: "Yunus", arabic: "سُورَةُ يُونُسَ", meaning: "Jonas", revelation: "Meccan", ayahs: 109, page: 208, juz: 11 },
+  { n: 11, slug: "hud", translit: "Hud", arabic: "سُورَةُ هُودٍ", meaning: "Hud", revelation: "Meccan", ayahs: 123, page: 221, juz: 11 },
+  { n: 12, slug: "yusuf", translit: "Yusuf", arabic: "سُورَةُ يُوسُفَ", meaning: "Joseph", revelation: "Meccan", ayahs: 111, page: 235, juz: 12 },
+  { n: 13, slug: "ar-rad", translit: "Ar-Rad", arabic: "سُورَةُ الرَّعۡدِ", meaning: "The Thunder", revelation: "Medinan", ayahs: 43, page: 249, juz: 13 },
+  { n: 14, slug: "ibrahim", translit: "Ibrahim", arabic: "سُورَةُ إِبۡرَاهِيمَ", meaning: "Abraham", revelation: "Meccan", ayahs: 52, page: 255, juz: 13 },
+  { n: 15, slug: "al-hijr", translit: "Al-Hijr", arabic: "سُورَةُ الحِجۡرِ", meaning: "The Rock", revelation: "Meccan", ayahs: 99, page: 262, juz: 14 },
+  { n: 16, slug: "an-nahl", translit: "An-Nahl", arabic: "سُورَةُ النَّحۡلِ", meaning: "The Bee", revelation: "Meccan", ayahs: 128, page: 267, juz: 14 },
+  { n: 17, slug: "al-isra", translit: "Al-Isra", arabic: "سُورَةُ الإِسۡرَاءِ", meaning: "The Night Journey", revelation: "Meccan", ayahs: 111, page: 282, juz: 15 },
+  { n: 18, slug: "al-kahf", translit: "Al-Kahf", arabic: "سُورَةُ الكَهۡفِ", meaning: "The Cave", revelation: "Meccan", ayahs: 110, page: 293, juz: 15 },
+  { n: 19, slug: "maryam", translit: "Maryam", arabic: "سُورَةُ مَرۡيَمَ", meaning: "Mary", revelation: "Meccan", ayahs: 98, page: 305, juz: 16 },
+  { n: 20, slug: "taha", translit: "Ta-Ha", arabic: "سُورَةُ طه", meaning: "Taa-Haa", revelation: "Meccan", ayahs: 135, page: 312, juz: 16 },
+  { n: 21, slug: "al-anbiya", translit: "Al-Anbiya", arabic: "سُورَةُ الأَنبِيَاءِ", meaning: "The Prophets", revelation: "Meccan", ayahs: 112, page: 322, juz: 17 },
+  { n: 22, slug: "al-hajj", translit: "Al-Hajj", arabic: "سُورَةُ الحَجِّ", meaning: "The Pilgrimage", revelation: "Medinan", ayahs: 78, page: 332, juz: 17 },
+  { n: 23, slug: "al-muminun", translit: "Al-Muminun", arabic: "سُورَةُ المُؤۡمِنُونَ", meaning: "The Believers", revelation: "Meccan", ayahs: 118, page: 342, juz: 18 },
+  { n: 24, slug: "an-nur", translit: "An-Nur", arabic: "سُورَةُ النُّورِ", meaning: "The Light", revelation: "Medinan", ayahs: 64, page: 350, juz: 18 },
+  { n: 25, slug: "al-furqan", translit: "Al-Furqan", arabic: "سُورَةُ الفُرۡقَانِ", meaning: "The Criterion", revelation: "Meccan", ayahs: 77, page: 359, juz: 18 },
+  { n: 26, slug: "ash-shuara", translit: "Ash-Shuara", arabic: "سُورَةُ الشُّعَرَاءِ", meaning: "The Poets", revelation: "Meccan", ayahs: 227, page: 367, juz: 19 },
+  { n: 27, slug: "an-naml", translit: "An-Naml", arabic: "سُورَةُ النَّمۡلِ", meaning: "The Ant", revelation: "Meccan", ayahs: 93, page: 377, juz: 19 },
+  { n: 28, slug: "al-qasas", translit: "Al-Qasas", arabic: "سُورَةُ القَصَصِ", meaning: "The Stories", revelation: "Meccan", ayahs: 88, page: 385, juz: 20 },
+  { n: 29, slug: "al-ankabut", translit: "Al-Ankabut", arabic: "سُورَةُ العَنكَبُوتِ", meaning: "The Spider", revelation: "Meccan", ayahs: 69, page: 396, juz: 20 },
+  { n: 30, slug: "ar-rum", translit: "Ar-Rum", arabic: "سُورَةُ الرُّومِ", meaning: "The Romans", revelation: "Meccan", ayahs: 60, page: 404, juz: 21 },
+  { n: 31, slug: "luqman", translit: "Luqman", arabic: "سُورَةُ لُقۡمَانَ", meaning: "Luqman", revelation: "Meccan", ayahs: 34, page: 411, juz: 21 },
+  { n: 32, slug: "as-sajdah", translit: "As-Sajdah", arabic: "سُورَةُ السَّجۡدَةِ", meaning: "The Prostration", revelation: "Meccan", ayahs: 30, page: 415, juz: 21 },
+  { n: 33, slug: "al-ahzab", translit: "Al-Ahzab", arabic: "سُورَةُ الأَحۡزَابِ", meaning: "The Clans", revelation: "Medinan", ayahs: 73, page: 418, juz: 21 },
+  { n: 34, slug: "saba", translit: "Saba", arabic: "سُورَةُ سَبَإٍ", meaning: "Sheba", revelation: "Meccan", ayahs: 54, page: 428, juz: 22 },
+  { n: 35, slug: "fatir", translit: "Fatir", arabic: "سُورَةُ فَاطِرٍ", meaning: "The Originator", revelation: "Meccan", ayahs: 45, page: 434, juz: 22 },
+  { n: 36, slug: "yasin", translit: "Ya-Sin", arabic: "سُورَةُ يسٓ", meaning: "Yaseen", revelation: "Meccan", ayahs: 83, page: 440, juz: 22 },
+  { n: 37, slug: "as-saffat", translit: "As-Saffat", arabic: "سُورَةُ الصَّافَّاتِ", meaning: "Those drawn up in Ranks", revelation: "Meccan", ayahs: 182, page: 446, juz: 23 },
+  { n: 38, slug: "sad", translit: "Sad", arabic: "سُورَةُ صٓ", meaning: "The letter Saad", revelation: "Meccan", ayahs: 88, page: 453, juz: 23 },
+  { n: 39, slug: "az-zumar", translit: "Az-Zumar", arabic: "سُورَةُ الزُّمَرِ", meaning: "The Groups", revelation: "Meccan", ayahs: 75, page: 458, juz: 23 },
+  { n: 40, slug: "ghafir", translit: "Ghafir", arabic: "سُورَةُ غَافِرٍ", meaning: "The Forgiver", revelation: "Meccan", ayahs: 85, page: 467, juz: 24 },
+  { n: 41, slug: "fussilat", translit: "Fussilat", arabic: "سُورَةُ فُصِّلَتۡ", meaning: "Explained in detail", revelation: "Meccan", ayahs: 54, page: 477, juz: 24 },
+  { n: 42, slug: "ash-shura", translit: "Ash-Shura", arabic: "سُورَةُ الشُّورَىٰ", meaning: "Consultation", revelation: "Meccan", ayahs: 53, page: 483, juz: 25 },
+  { n: 43, slug: "az-zukhruf", translit: "Az-Zukhruf", arabic: "سُورَةُ الزُّخۡرُفِ", meaning: "Ornaments of gold", revelation: "Meccan", ayahs: 89, page: 489, juz: 25 },
+  { n: 44, slug: "ad-dukhan", translit: "Ad-Dukhan", arabic: "سُورَةُ الدُّخَانِ", meaning: "The Smoke", revelation: "Meccan", ayahs: 59, page: 496, juz: 25 },
+  { n: 45, slug: "al-jathiyah", translit: "Al-Jathiyah", arabic: "سُورَةُ الجَاثِيَةِ", meaning: "Crouching", revelation: "Meccan", ayahs: 37, page: 499, juz: 25 },
+  { n: 46, slug: "al-ahqaf", translit: "Al-Ahqaf", arabic: "سُورَةُ الأَحۡقَافِ", meaning: "The Dunes", revelation: "Meccan", ayahs: 35, page: 502, juz: 26 },
+  { n: 47, slug: "muhammad", translit: "Muhammad", arabic: "سُورَةُ مُحَمَّدٍ", meaning: "Muhammad", revelation: "Medinan", ayahs: 38, page: 507, juz: 26 },
+  { n: 48, slug: "al-fath", translit: "Al-Fath", arabic: "سُورَةُ الفَتۡحِ", meaning: "The Victory", revelation: "Medinan", ayahs: 29, page: 511, juz: 26 },
+  { n: 49, slug: "al-hujurat", translit: "Al-Hujurat", arabic: "سُورَةُ الحُجُرَاتِ", meaning: "The Inner Apartments", revelation: "Medinan", ayahs: 18, page: 515, juz: 26 },
+  { n: 50, slug: "qaf", translit: "Qaf", arabic: "سُورَةُ قٓ", meaning: "The letter Qaaf", revelation: "Meccan", ayahs: 45, page: 518, juz: 26 },
+  { n: 51, slug: "adh-dhariyat", translit: "Adh-Dhariyat", arabic: "سُورَةُ الذَّارِيَاتِ", meaning: "The Winnowing Winds", revelation: "Meccan", ayahs: 60, page: 520, juz: 26 },
+  { n: 52, slug: "at-tur", translit: "At-Tur", arabic: "سُورَةُ الطُّورِ", meaning: "The Mount", revelation: "Meccan", ayahs: 49, page: 523, juz: 27 },
+  { n: 53, slug: "an-najm", translit: "An-Najm", arabic: "سُورَةُ النَّجۡمِ", meaning: "The Star", revelation: "Meccan", ayahs: 62, page: 526, juz: 27 },
+  { n: 54, slug: "al-qamar", translit: "Al-Qamar", arabic: "سُورَةُ القَمَرِ", meaning: "The Moon", revelation: "Meccan", ayahs: 55, page: 528, juz: 27 },
+  { n: 55, slug: "ar-rahman", translit: "Ar-Rahman", arabic: "سُورَةُ الرَّحۡمَٰن", meaning: "The Beneficent", revelation: "Medinan", ayahs: 78, page: 531, juz: 27 },
+  { n: 56, slug: "al-waqiah", translit: "Al-Waqiah", arabic: "سُورَةُ الوَاقِعَةِ", meaning: "The Inevitable", revelation: "Meccan", ayahs: 96, page: 534, juz: 27 },
+  { n: 57, slug: "al-hadid", translit: "Al-Hadid", arabic: "سُورَةُ الحَدِيدِ", meaning: "The Iron", revelation: "Medinan", ayahs: 29, page: 537, juz: 27 },
+  { n: 58, slug: "al-mujadila", translit: "Al-Mujadila", arabic: "سُورَةُ المُجَادلَةِ", meaning: "The Pleading Woman", revelation: "Medinan", ayahs: 22, page: 542, juz: 28 },
+  { n: 59, slug: "al-hashr", translit: "Al-Hashr", arabic: "سُورَةُ الحَشۡرِ", meaning: "The Exile", revelation: "Medinan", ayahs: 24, page: 545, juz: 28 },
+  { n: 60, slug: "al-mumtahanah", translit: "Al-Mumtahanah", arabic: "سُورَةُ المُمۡتَحنَةِ", meaning: "She that is to be examined", revelation: "Medinan", ayahs: 13, page: 549, juz: 28 },
+  { n: 61, slug: "as-saff", translit: "As-Saff", arabic: "سُورَةُ الصَّفِّ", meaning: "The Ranks", revelation: "Medinan", ayahs: 14, page: 551, juz: 28 },
+  { n: 62, slug: "al-jumuah", translit: "Al-Jumuah", arabic: "سُورَةُ الجُمُعَةِ", meaning: "Friday", revelation: "Medinan", ayahs: 11, page: 553, juz: 28 },
+  { n: 63, slug: "al-munafiqun", translit: "Al-Munafiqun", arabic: "سُورَةُ المُنَافِقُونَ", meaning: "The Hypocrites", revelation: "Medinan", ayahs: 11, page: 554, juz: 28 },
+  { n: 64, slug: "at-taghabun", translit: "At-Taghabun", arabic: "سُورَةُ التَّغَابُنِ", meaning: "Mutual Disillusion", revelation: "Medinan", ayahs: 18, page: 556, juz: 28 },
+  { n: 65, slug: "at-talaq", translit: "At-Talaq", arabic: "سُورَةُ الطَّلَاقِ", meaning: "Divorce", revelation: "Medinan", ayahs: 12, page: 558, juz: 28 },
+  { n: 66, slug: "at-tahrim", translit: "At-Tahrim", arabic: "سُورَةُ التَّحۡرِيمِ", meaning: "The Prohibition", revelation: "Medinan", ayahs: 12, page: 560, juz: 28 },
+  { n: 67, slug: "al-mulk", translit: "Al-Mulk", arabic: "سُورَةُ المُلۡكِ", meaning: "The Sovereignty", revelation: "Meccan", ayahs: 30, page: 562, juz: 29 },
+  { n: 68, slug: "al-qalam", translit: "Al-Qalam", arabic: "سُورَةُ القَلَمِ", meaning: "The Pen", revelation: "Meccan", ayahs: 52, page: 564, juz: 29 },
+  { n: 69, slug: "al-haqqah", translit: "Al-Haqqah", arabic: "سُورَةُ الحَاقَّةِ", meaning: "The Reality", revelation: "Meccan", ayahs: 52, page: 566, juz: 29 },
+  { n: 70, slug: "al-maarij", translit: "Al-Maarij", arabic: "سُورَةُ المَعَارِجِ", meaning: "The Ascending Stairways", revelation: "Meccan", ayahs: 44, page: 568, juz: 29 },
+  { n: 71, slug: "nuh", translit: "Nuh", arabic: "سُورَةُ نُوحٍ", meaning: "Noah", revelation: "Meccan", ayahs: 28, page: 570, juz: 29 },
+  { n: 72, slug: "al-jinn", translit: "Al-Jinn", arabic: "سُورَةُ الجِنِّ", meaning: "The Jinn", revelation: "Meccan", ayahs: 28, page: 572, juz: 29 },
+  { n: 73, slug: "al-muzzammil", translit: "Al-Muzzammil", arabic: "سُورَةُ المُزَّمِّلِ", meaning: "The Enshrouded One", revelation: "Meccan", ayahs: 20, page: 574, juz: 29 },
+  { n: 74, slug: "al-muddaththir", translit: "Al-Muddaththir", arabic: "سُورَةُ المُدَّثِّرِ", meaning: "The Cloaked One", revelation: "Meccan", ayahs: 56, page: 575, juz: 29 },
+  { n: 75, slug: "al-qiyamah", translit: "Al-Qiyamah", arabic: "سُورَةُ القِيَامَةِ", meaning: "The Resurrection", revelation: "Meccan", ayahs: 40, page: 577, juz: 29 },
+  { n: 76, slug: "al-insan", translit: "Al-Insan", arabic: "سُورَةُ الإِنسَانِ", meaning: "Man", revelation: "Medinan", ayahs: 31, page: 578, juz: 29 },
+  { n: 77, slug: "al-mursalat", translit: "Al-Mursalat", arabic: "سُورَةُ المُرۡسَلَاتِ", meaning: "The Emissaries", revelation: "Meccan", ayahs: 50, page: 580, juz: 29 },
+  { n: 78, slug: "an-naba", translit: "An-Naba", arabic: "سُورَةُ النَّبَإِ", meaning: "The Announcement", revelation: "Meccan", ayahs: 40, page: 582, juz: 30 },
+  { n: 79, slug: "an-naziat", translit: "An-Naziat", arabic: "سُورَةُ النَّازِعَاتِ", meaning: "Those who drag forth", revelation: "Meccan", ayahs: 46, page: 583, juz: 30 },
+  { n: 80, slug: "abasa", translit: "Abasa", arabic: "سُورَةُ عَبَسَ", meaning: "He frowned", revelation: "Meccan", ayahs: 42, page: 585, juz: 30 },
+  { n: 81, slug: "at-takwir", translit: "At-Takwir", arabic: "سُورَةُ التَّكۡوِيرِ", meaning: "The Overthrowing", revelation: "Meccan", ayahs: 29, page: 586, juz: 30 },
+  { n: 82, slug: "al-infitar", translit: "Al-Infitar", arabic: "سُورَةُ الانفِطَارِ", meaning: "The Cleaving", revelation: "Meccan", ayahs: 19, page: 587, juz: 30 },
+  { n: 83, slug: "al-mutaffifin", translit: "Al-Mutaffifin", arabic: "سُورَةُ المُطَفِّفِينَ", meaning: "Defrauding", revelation: "Meccan", ayahs: 36, page: 587, juz: 30 },
+  { n: 84, slug: "al-inshiqaq", translit: "Al-Inshiqaq", arabic: "سُورَةُ الانشِقَاقِ", meaning: "The Splitting Open", revelation: "Meccan", ayahs: 25, page: 589, juz: 30 },
+  { n: 85, slug: "al-buruj", translit: "Al-Buruj", arabic: "سُورَةُ البُرُوجِ", meaning: "The Constellations", revelation: "Meccan", ayahs: 22, page: 590, juz: 30 },
+  { n: 86, slug: "at-tariq", translit: "At-Tariq", arabic: "سُورَةُ الطَّارِقِ", meaning: "The Morning Star", revelation: "Meccan", ayahs: 17, page: 591, juz: 30 },
+  { n: 87, slug: "al-ala", translit: "Al-Ala", arabic: "سُورَةُ الأَعۡلَىٰ", meaning: "The Most High", revelation: "Meccan", ayahs: 19, page: 591, juz: 30 },
+  { n: 88, slug: "al-ghashiyah", translit: "Al-Ghashiyah", arabic: "سُورَةُ الغَاشِيَةِ", meaning: "The Overwhelming", revelation: "Meccan", ayahs: 26, page: 592, juz: 30 },
+  { n: 89, slug: "al-fajr", translit: "Al-Fajr", arabic: "سُورَةُ الفَجۡرِ", meaning: "The Dawn", revelation: "Meccan", ayahs: 30, page: 593, juz: 30 },
+  { n: 90, slug: "al-balad", translit: "Al-Balad", arabic: "سُورَةُ البَلَدِ", meaning: "The City", revelation: "Meccan", ayahs: 20, page: 594, juz: 30 },
+  { n: 91, slug: "ash-shams", translit: "Ash-Shams", arabic: "سُورَةُ الشَّمۡسِ", meaning: "The Sun", revelation: "Meccan", ayahs: 15, page: 595, juz: 30 },
+  { n: 92, slug: "al-layl", translit: "Al-Layl", arabic: "سُورَةُ اللَّيۡلِ", meaning: "The Night", revelation: "Meccan", ayahs: 21, page: 595, juz: 30 },
+  { n: 93, slug: "ad-duha", translit: "Ad-Duha", arabic: "سُورَةُ الضُّحَىٰ", meaning: "The Morning Hours", revelation: "Meccan", ayahs: 11, page: 596, juz: 30 },
+  { n: 94, slug: "ash-sharh", translit: "Ash-Sharh", arabic: "سُورَةُ الشَّرۡحِ", meaning: "The Consolation", revelation: "Meccan", ayahs: 8, page: 596, juz: 30 },
+  { n: 95, slug: "at-tin", translit: "At-Tin", arabic: "سُورَةُ التِّينِ", meaning: "The Fig", revelation: "Meccan", ayahs: 8, page: 597, juz: 30 },
+  { n: 96, slug: "al-alaq", translit: "Al-Alaq", arabic: "سُورَةُ العَلَقِ", meaning: "The Clot", revelation: "Meccan", ayahs: 19, page: 597, juz: 30 },
+  { n: 97, slug: "al-qadr", translit: "Al-Qadr", arabic: "سُورَةُ القَدۡرِ", meaning: "The Power, Fate", revelation: "Meccan", ayahs: 5, page: 598, juz: 30 },
+  { n: 98, slug: "al-bayyinah", translit: "Al-Bayyinah", arabic: "سُورَةُ البَيِّنَةِ", meaning: "The Evidence", revelation: "Medinan", ayahs: 8, page: 598, juz: 30 },
+  { n: 99, slug: "az-zalzalah", translit: "Az-Zalzalah", arabic: "سُورَةُ الزَّلۡزَلَةِ", meaning: "The Earthquake", revelation: "Medinan", ayahs: 8, page: 599, juz: 30 },
+  { n: 100, slug: "al-adiyat", translit: "Al-Adiyat", arabic: "سُورَةُ العَادِيَاتِ", meaning: "The Chargers", revelation: "Meccan", ayahs: 11, page: 599, juz: 30 },
+  { n: 101, slug: "al-qariah", translit: "Al-Qariah", arabic: "سُورَةُ القَارِعَةِ", meaning: "The Calamity", revelation: "Meccan", ayahs: 11, page: 600, juz: 30 },
+  { n: 102, slug: "at-takathur", translit: "At-Takathur", arabic: "سُورَةُ التَّكَاثُرِ", meaning: "Competition", revelation: "Meccan", ayahs: 8, page: 600, juz: 30 },
+  { n: 103, slug: "al-asr", translit: "Al-Asr", arabic: "سُورَةُ العَصۡرِ", meaning: "The Declining Day, Epoch", revelation: "Meccan", ayahs: 3, page: 601, juz: 30 },
+  { n: 104, slug: "al-humazah", translit: "Al-Humazah", arabic: "سُورَةُ الهُمَزَةِ", meaning: "The Traducer", revelation: "Meccan", ayahs: 9, page: 601, juz: 30 },
+  { n: 105, slug: "al-fil", translit: "Al-Fil", arabic: "سُورَةُ الفِيلِ", meaning: "The Elephant", revelation: "Meccan", ayahs: 5, page: 601, juz: 30 },
+  { n: 106, slug: "quraysh", translit: "Quraysh", arabic: "سُورَةُ قُرَيۡشٍ", meaning: "Quraysh", revelation: "Meccan", ayahs: 4, page: 602, juz: 30 },
+  { n: 107, slug: "al-maun", translit: "Al-Maun", arabic: "سُورَةُ المَاعُونِ", meaning: "Almsgiving", revelation: "Meccan", ayahs: 7, page: 602, juz: 30 },
+  { n: 108, slug: "al-kawthar", translit: "Al-Kawthar", arabic: "سُورَةُ الكَوۡثَرِ", meaning: "Abundance", revelation: "Meccan", ayahs: 3, page: 602, juz: 30 },
+  { n: 109, slug: "al-kafirun", translit: "Al-Kafirun", arabic: "سُورَةُ الكَافِرُونَ", meaning: "The Disbelievers", revelation: "Meccan", ayahs: 6, page: 603, juz: 30 },
+  { n: 110, slug: "an-nasr", translit: "An-Nasr", arabic: "سُورَةُ النَّصۡرِ", meaning: "Divine Support", revelation: "Medinan", ayahs: 3, page: 603, juz: 30 },
+  { n: 111, slug: "al-masad", translit: "Al-Masad", arabic: "سُورَةُ المَسَدِ", meaning: "The Palm Fibre", revelation: "Meccan", ayahs: 5, page: 603, juz: 30 },
+  { n: 112, slug: "al-ikhlas", translit: "Al-Ikhlas", arabic: "سُورَةُ الإِخۡلَاصِ", meaning: "Sincerity", revelation: "Meccan", ayahs: 4, page: 604, juz: 30 },
+  { n: 113, slug: "al-falaq", translit: "Al-Falaq", arabic: "سُورَةُ الفَلَقِ", meaning: "The Dawn", revelation: "Meccan", ayahs: 5, page: 604, juz: 30 },
+  { n: 114, slug: "an-nas", translit: "An-Nas", arabic: "سُورَةُ النَّاسِ", meaning: "Mankind", revelation: "Meccan", ayahs: 6, page: 604, juz: 30 },
+];
+
+export const JUZ: JuzMeta[] = [
+  { n: 1, arabic: "آلم", translit: "Alif Lam Mim", start: [1, 1] },
+  { n: 2, arabic: "سَيَقُولُ", translit: "Sayaqul", start: [2, 142] },
+  { n: 3, arabic: "تِلْكَ ٱلرُّسُل", translit: "Tilka ar-Rusul", start: [2, 253] },
+  { n: 4, arabic: "لَن تَنَالُوا۟", translit: "Lan Tanalu", start: [3, 93] },
+  { n: 5, arabic: "وَٱلْمُحْصَنَٰت", translit: "Wal-Muhsanat", start: [4, 24] },
+  { n: 6, arabic: "لَا يُحِبُّ ٱللَّه", translit: "La Yuhibbullah", start: [4, 148] },
+  { n: 7, arabic: "وَإِذَا سَمِعُوا۟", translit: "Wa Idha Sami'u", start: [5, 82] },
+  { n: 8, arabic: "وَلَوْ أَنَّنَا", translit: "Wa Lau Annana", start: [6, 111] },
+  { n: 9, arabic: "قَالَ ٱلْمَلَأ", translit: "Qalal Mala'u", start: [7, 88] },
+  { n: 10, arabic: "وَٱعْلَمُوٓا۟", translit: "Wa'lamu", start: [8, 41] },
+  { n: 11, arabic: "يَعْتَذِرُونَ", translit: "Ya'tadhirun", start: [9, 93] },
+  { n: 12, arabic: "وَمَا مِن دَآبَّة", translit: "Wa Ma Min Dabbah", start: [11, 6] },
+  { n: 13, arabic: "وَمَآ أُبَرِّئُ", translit: "Wa Ma Ubarri'u", start: [12, 53] },
+  { n: 14, arabic: "رُبَمَا", translit: "Rubama", start: [15, 1] },
+  { n: 15, arabic: "سُبْحَٰنَ ٱلَّذِى", translit: "Subhanalladhi", start: [17, 1] },
+  { n: 16, arabic: "قَالَ أَلَمْ", translit: "Qala Alam", start: [18, 75] },
+  { n: 17, arabic: "ٱقْتَرَبَ لِلنَّاسِ", translit: "Iqtaraba Lin-Nas", start: [21, 1] },
+  { n: 18, arabic: "قَدْ أَفْلَحَ", translit: "Qad Aflaha", start: [23, 1] },
+  { n: 19, arabic: "وَقَالَ ٱلَّذِينَ", translit: "Wa Qalalladhina", start: [25, 21] },
+  { n: 20, arabic: "أَمَّنْ خَلَقَ", translit: "Amman Khalaqa", start: [27, 56] },
+  { n: 21, arabic: "ٱتْلُ مَآ أُوحِىَ", translit: "Utlu Ma Uhiya", start: [29, 46] },
+  { n: 22, arabic: "وَمَن يَقْنُتْ", translit: "Wa Man Yaqnut", start: [33, 31] },
+  { n: 23, arabic: "وَمَا لِىَ", translit: "Wa Ma Liya", start: [36, 28] },
+  { n: 24, arabic: "فَمَنْ أَظْلَمُ", translit: "Faman Azlamu", start: [39, 32] },
+  { n: 25, arabic: "إِلَيْهِ يُرَدُّ", translit: "Ilayhi Yuraddu", start: [41, 47] },
+  { n: 26, arabic: "حمٓ", translit: "Ha Mim", start: [46, 1] },
+  { n: 27, arabic: "قَالَ فَمَا خَطْبُكُمْ", translit: "Qala Fama Khatbukum", start: [51, 31] },
+  { n: 28, arabic: "قَدْ سَمِعَ ٱللَّهُ", translit: "Qad Sami'allahu", start: [58, 1] },
+  { n: 29, arabic: "تَبَٰرَكَ ٱلَّذِى", translit: "Tabarakalladhi", start: [67, 1] },
+  { n: 30, arabic: "عَمَّ", translit: "'Amma", start: [78, 1] },
+];
+
+export const HIZB: HizbMeta[] = [
+  { n: 1, juz: 1, start: [1, 1] },
+  { n: 2, juz: 1, start: [2, 75] },
+  { n: 3, juz: 2, start: [2, 142] },
+  { n: 4, juz: 2, start: [2, 203] },
+  { n: 5, juz: 3, start: [2, 253] },
+  { n: 6, juz: 3, start: [3, 15] },
+  { n: 7, juz: 4, start: [3, 93] },
+  { n: 8, juz: 4, start: [3, 171] },
+  { n: 9, juz: 5, start: [4, 24] },
+  { n: 10, juz: 5, start: [4, 88] },
+  { n: 11, juz: 6, start: [4, 148] },
+  { n: 12, juz: 6, start: [5, 27] },
+  { n: 13, juz: 7, start: [5, 82] },
+  { n: 14, juz: 7, start: [6, 36] },
+  { n: 15, juz: 8, start: [6, 111] },
+  { n: 16, juz: 8, start: [7, 1] },
+  { n: 17, juz: 9, start: [7, 88] },
+  { n: 18, juz: 9, start: [7, 171] },
+  { n: 19, juz: 10, start: [8, 41] },
+  { n: 20, juz: 10, start: [9, 34] },
+  { n: 21, juz: 11, start: [9, 93] },
+  { n: 22, juz: 11, start: [10, 26] },
+  { n: 23, juz: 12, start: [11, 6] },
+  { n: 24, juz: 12, start: [11, 84] },
+  { n: 25, juz: 13, start: [12, 53] },
+  { n: 26, juz: 13, start: [13, 19] },
+  { n: 27, juz: 14, start: [15, 1] },
+  { n: 28, juz: 14, start: [16, 51] },
+  { n: 29, juz: 15, start: [17, 1] },
+  { n: 30, juz: 15, start: [17, 99] },
+  { n: 31, juz: 16, start: [18, 75] },
+  { n: 32, juz: 16, start: [20, 1] },
+  { n: 33, juz: 17, start: [21, 1] },
+  { n: 34, juz: 17, start: [22, 1] },
+  { n: 35, juz: 18, start: [23, 1] },
+  { n: 36, juz: 18, start: [24, 21] },
+  { n: 37, juz: 19, start: [25, 21] },
+  { n: 38, juz: 19, start: [26, 111] },
+  { n: 39, juz: 20, start: [27, 56] },
+  { n: 40, juz: 20, start: [28, 51] },
+  { n: 41, juz: 21, start: [29, 46] },
+  { n: 42, juz: 21, start: [31, 22] },
+  { n: 43, juz: 22, start: [33, 31] },
+  { n: 44, juz: 22, start: [34, 24] },
+  { n: 45, juz: 23, start: [36, 28] },
+  { n: 46, juz: 23, start: [37, 145] },
+  { n: 47, juz: 24, start: [39, 32] },
+  { n: 48, juz: 24, start: [40, 41] },
+  { n: 49, juz: 25, start: [41, 47] },
+  { n: 50, juz: 25, start: [43, 24] },
+  { n: 51, juz: 26, start: [46, 1] },
+  { n: 52, juz: 26, start: [48, 18] },
+  { n: 53, juz: 27, start: [51, 31] },
+  { n: 54, juz: 27, start: [55, 1] },
+  { n: 55, juz: 28, start: [58, 1] },
+  { n: 56, juz: 28, start: [62, 1] },
+  { n: 57, juz: 29, start: [67, 1] },
+  { n: 58, juz: 29, start: [72, 1] },
+  { n: 59, juz: 30, start: [78, 1] },
+  { n: 60, juz: 30, start: [87, 1] },
+];
+
+const BY_SLUG = new Map(SURAHS.map((s) => [s.slug, s]));
+
+export const surahBySlug = (slug: string): SurahMeta | undefined => BY_SLUG.get(slug);
+export const surahByNumber = (n: number): SurahMeta | undefined => SURAHS[n - 1];
+export const juzByNumber = (n: number): JuzMeta | undefined => JUZ[n - 1];
+export const hizbByNumber = (n: number): HizbMeta | undefined => HIZB[n - 1];

--- a/lib/quran-page.ts
+++ b/lib/quran-page.ts
@@ -1,0 +1,147 @@
+/** Assembles one Quran route: the verses to read, the copy that wraps them,
+ * and the links out to the other three views of the same text.
+ *
+ * Every route family (/surah, /juz, /hizb, /page) is the same page with a
+ * different slice, so the slicing and the wording live here rather than being
+ * repeated four times. */
+
+import { getDict, localePath, type Locale } from "./i18n";
+import { quranText } from "./quran-build";
+import { HIZB, JUZ, SURAHS, TOTAL_PAGES } from "./quran-meta";
+import type { BrowseMode, ReaderUnit } from "./quran-reader";
+import {
+  hizbPath,
+  juzName,
+  juzPath,
+  mushafPath,
+  shortSurahList,
+  surahListLabel,
+  surahName,
+  surahPath,
+  verseRef,
+} from "./quran-seo";
+
+const AR_DIGITS = ["٠", "١", "٢", "٣", "٤", "٥", "٦", "٧", "٨", "٩"];
+const toArabicNum = (n: number) =>
+  String(n)
+    .split("")
+    .map((c) => AR_DIGITS[Number(c)] ?? c)
+    .join("");
+
+export type QuranPage = {
+  unit: ReaderUnit;
+  /** What the tool shell shows: H1, the opposite-script ornament, intro prose. */
+  heading: { title: string; side: string; intro: string };
+  /** <title> and <meta name="description">. */
+  title: string;
+  description: string;
+  crumb: string;
+  /** Cross-links to the same passage seen as juz / hizb / page / surah. */
+  related: { href: string; label: string }[];
+  path: string;
+};
+
+export async function buildQuranPage(
+  locale: Locale,
+  mode: BrowseMode,
+  n: number,
+): Promise<QuranPage> {
+  const b = getDict(locale).quranBrowse;
+  const text = await quranText(locale);
+  const ayahs =
+    mode === "surah"
+      ? (text.bySurah.get(n) ?? [])
+      : mode === "juz"
+        ? (text.byJuz.get(n) ?? [])
+        : mode === "hizb"
+          ? (text.byHizb.get(n) ?? [])
+          : (text.byPage.get(n) ?? []);
+
+  const unit: ReaderUnit = { mode, n, ayahs, edition: text.edition };
+  const first = ayahs[0];
+  const last = ayahs.at(-1);
+  const from = first ? verseRef(locale, first.surah, first.ayah) : "";
+  const to = last ? verseRef(locale, last.surah, last.ayah) : "";
+  const surahNumbers = [...new Set(ayahs.map((a) => a.surah))];
+  const juzNumbers = [...new Set(ayahs.map((a) => a.juz))];
+  const hizbNumbers = [...new Set(ayahs.map((a) => a.hizb))];
+  const pageNumbers = [...new Set(ayahs.map((a) => a.page))];
+
+  const link = (href: string, label: string) => ({ href: localePath(locale, href), label });
+  const surahLinks = surahNumbers.map((s) =>
+    link(surahPath(SURAHS[s - 1].slug), `${b.surah} ${surahName(locale, SURAHS[s - 1])}`),
+  );
+  const juzLinks = juzNumbers.map((j) => link(juzPath(j), `${b.juz} ${j}`));
+  const hizbLinks = hizbNumbers.map((h) => link(hizbPath(h), `${b.hizb} ${h}`));
+  // A long surah touches dozens of pages; a handful is enough of a crawl path.
+  const pageLinks = pageNumbers.slice(0, 12).map((p) => link(mushafPath(p), `${b.page} ${p}`));
+
+  if (mode === "surah") {
+    const s = SURAHS[n - 1];
+    const name = surahName(locale, s);
+    const revelation = s.revelation === "Meccan" ? b.meccan : b.medinan;
+    return {
+      unit,
+      path: surahPath(s.slug),
+      crumb: `${b.surah} ${name}`,
+      title: b.surahTitle(name, s.meaning, s.n),
+      description: b.surahDesc(name, s.n, s.meaning, s.ayahs, revelation, s.juz),
+      heading: {
+        title: b.surahH1(name),
+        side: locale === "ar" ? s.translit : s.arabic,
+        intro: b.surahIntro(name, s.n, s.meaning, s.ayahs, revelation, s.juz, s.page),
+      },
+      related: [...juzLinks, ...hizbLinks, ...pageLinks],
+    };
+  }
+
+  if (mode === "juz") {
+    const j = JUZ[n - 1];
+    const name = juzName(locale, n);
+    return {
+      unit,
+      path: juzPath(n),
+      crumb: `${b.juz} ${n}`,
+      title: b.juzTitle(n, name),
+      description: b.juzDesc(n, name, from, to, ayahs.length),
+      heading: {
+        title: b.juzH1(n),
+        side: locale === "ar" ? j.translit : j.arabic,
+        intro: b.juzIntro(n, name, from, to, ayahs.length, surahNumbers.length),
+      },
+      related: [...surahLinks, ...hizbLinks],
+    };
+  }
+
+  if (mode === "hizb") {
+    const h = HIZB[n - 1];
+    return {
+      unit,
+      path: hizbPath(n),
+      crumb: `${b.hizb} ${n}`,
+      title: b.hizbTitle(n, h.juz),
+      description: b.hizbDesc(n, h.juz, from, to, ayahs.length),
+      heading: {
+        title: b.hizbH1(n),
+        side: locale === "ar" ? `Hizb ${n}` : JUZ[h.juz - 1].arabic,
+        intro: b.hizbIntro(n, h.juz, from, to, ayahs.length),
+      },
+      related: [link(juzPath(h.juz), `${b.juz} ${h.juz}`), ...surahLinks],
+    };
+  }
+
+  const juz = first?.juz ?? 1;
+  return {
+    unit,
+    path: mushafPath(n),
+    crumb: `${b.page} ${n}`,
+    title: b.pageTitle(n, shortSurahList(locale, surahNumbers), juz),
+    description: b.pageDesc(n, juz, surahListLabel(locale, surahNumbers), ayahs.length),
+    heading: {
+      title: b.pageH1(n),
+      side: locale === "ar" ? `Page ${n} / ${TOTAL_PAGES}` : `﴿ ${toArabicNum(n)} ﴾`,
+      intro: b.pageIntro(n, juz, surahListLabel(locale, surahNumbers), ayahs.length),
+    },
+    related: [...juzLinks, ...hizbLinks, ...surahLinks],
+  };
+}

--- a/lib/quran-reader.ts
+++ b/lib/quran-reader.ts
@@ -1,0 +1,123 @@
+/** Shared, client-safe types and helpers for the Quran reader.
+ *
+ * Kept separate from `quran-build.ts` (which touches node:fs) so the reader
+ * can import these without dragging server-only code into the bundle. */
+
+import { localePath, type Locale } from "./i18n";
+import { SURAHS, TOTAL_HIZB, TOTAL_JUZ, TOTAL_PAGES, TOTAL_SURAHS } from "./quran-meta";
+import { hizbPath, juzPath, mushafPath, surahPath } from "./quran-seo";
+
+/** The four ways the mushaf is conventionally divided — and the four route
+ * families. Every one of them is a real URL. */
+export type BrowseMode = "surah" | "juz" | "hizb" | "page";
+
+export type ReaderAyah = {
+  /** Global ayah number, 1–6236 — also the recitation file name. */
+  n: number;
+  surah: number;
+  ayah: number;
+  page: number;
+  juz: number;
+  hizb: number;
+  arabic: string;
+  translation: string;
+};
+
+/** Everything the reader needs to draw a unit, handed down from the server so
+ * the verses are in the prerendered HTML rather than fetched after paint. */
+export type ReaderUnit = {
+  mode: BrowseMode;
+  /** Surah number, juz, hizb or mushaf page, depending on `mode`. */
+  n: number;
+  ayahs: ReaderAyah[];
+  /** The translation edition `ayahs[].translation` holds. */
+  edition: string;
+};
+
+export const UNIT_TOTAL: Record<BrowseMode, number> = {
+  surah: TOTAL_SURAHS,
+  juz: TOTAL_JUZ,
+  hizb: TOTAL_HIZB,
+  page: TOTAL_PAGES,
+};
+
+/** Which unit of `mode` a given verse belongs to — used to keep your place
+ * when switching between surah, juz, hizb and page. */
+export function unitOf(mode: BrowseMode, ayah: ReaderAyah): number {
+  return mode === "surah" ? ayah.surah : mode === "juz" ? ayah.juz : mode === "hizb" ? ayah.hizb : ayah.page;
+}
+
+export function unitPath(locale: Locale, mode: BrowseMode, n: number): string {
+  const clamped = Math.min(UNIT_TOTAL[mode], Math.max(1, n));
+  const path =
+    mode === "surah"
+      ? surahPath(SURAHS[clamped - 1].slug)
+      : mode === "juz"
+        ? juzPath(clamped)
+        : mode === "hizb"
+          ? hizbPath(clamped)
+          : mushafPath(clamped);
+  return localePath(locale, path);
+}
+
+/** Reciters, with the bitrate their audio is actually published at — Abdul
+ * Basit is only on 64 and Sudais only on 192, and requesting the wrong one
+ * returns a 403. */
+export const RECITERS = [
+  { id: "ar.alafasy", name: "Mishary Alafasy", bitrate: 128 },
+  { id: "ar.husary", name: "Mahmoud Al-Husary", bitrate: 128 },
+  { id: "ar.abdurrahmaansudais", name: "Abdul Rahman Al-Sudais", bitrate: 192 },
+  { id: "ar.mahermuaiqly", name: "Maher Al-Muaiqly", bitrate: 128 },
+  { id: "ar.shaatree", name: "Abu Bakr Al-Shatri", bitrate: 128 },
+  { id: "ar.ahmedajamy", name: "Ahmed Al-Ajamy", bitrate: 128 },
+  { id: "ar.hudhaify", name: "Ali Al-Hudhaify", bitrate: 128 },
+  { id: "ar.abdulsamad", name: "Abdul Basit Abdul Samad", bitrate: 64 },
+];
+
+const BITRATE = new Map(RECITERS.map((r) => [r.id, r.bitrate]));
+
+/** Recitation URLs are addressable by global ayah number, so playback needs
+ * no API call at all — the reader works from the prerendered data alone. */
+export function audioUrl(reciter: string, globalAyah: number): string {
+  const rate = BITRATE.get(reciter) ?? 128;
+  return `https://cdn.islamic.network/quran/audio/${rate}/${reciter}/${globalAyah}.mp3`;
+}
+
+export const TRANSLATIONS = [
+  { id: "en.sahih", name: "Saheeh International · EN" },
+  { id: "en.pickthall", name: "Pickthall · EN" },
+  { id: "en.yusufali", name: "Yusuf Ali · EN" },
+  { id: "en.asad", name: "Muhammad Asad · EN" },
+  { id: "en.transliteration", name: "Transliteration" },
+  { id: "fr.hamidullah", name: "Hamidullah · FR" },
+  { id: "ar.muyassar", name: "التفسير الميسّر · AR" },
+];
+
+export const SPEEDS = [0.75, 1, 1.25, 1.5];
+
+const API = "https://api.alquran.cloud/v1";
+
+/** Fetch one unit in a different translation. Only called when the reader
+ * switches away from the edition the page was built with — the default never
+ * hits the network. A hizb has no endpoint of its own, so it is assembled
+ * from its four quarters. */
+export async function fetchUnitTranslation(
+  mode: BrowseMode,
+  n: number,
+  edition: string,
+): Promise<string[]> {
+  const paths =
+    mode === "hizb"
+      ? [4 * n - 3, 4 * n - 2, 4 * n - 1, 4 * n].map((q) => `hizbQuarter/${q}`)
+      : [`${mode}/${n}`];
+
+  const parts = await Promise.all(
+    paths.map(async (p) => {
+      const res = await fetch(`${API}/${p}/${edition}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+      return (json.data.ayahs as { text: string }[]).map((a) => a.text);
+    }),
+  );
+  return parts.flat();
+}

--- a/lib/quran-seo.ts
+++ b/lib/quran-seo.ts
@@ -1,0 +1,195 @@
+/** URLs, titles and structured data for the prerendered Quran routes.
+ *
+ * Four views of the same text, each answering a different query shape:
+ *   /quran/surah/al-kahf   "surah al kahf"
+ *   /quran/juz/30          "juz amma", "para 30"
+ *   /quran/hizb/59         "hizb 59"
+ *   /quran/page/255        "quran page 255"
+ * All four are self-canonical: they are genuinely different reading units,
+ * and each carries its own heading, prose and navigation. */
+
+import { bareArabic } from "./arabic";
+import { getDict, localePath, type Locale } from "./i18n";
+import { HIZB, JUZ, SURAHS, type SurahMeta, TOTAL_PAGES } from "./quran-meta";
+import { TOOL_PATHS } from "./seo";
+import { SITE_URL } from "./site";
+
+export const QURAN_PATH = TOOL_PATHS.quran;
+
+export const surahPath = (slug: string) => `${QURAN_PATH}/surah/${slug}`;
+export const juzPath = (n: number) => `${QURAN_PATH}/juz/${n}`;
+export const hizbPath = (n: number) => `${QURAN_PATH}/hizb/${n}`;
+export const mushafPath = (n: number) => `${QURAN_PATH}/page/${n}`;
+
+/** Every Quran URL the site publishes, for the sitemap. */
+export function quranPaths(): { path: string; priority: number }[] {
+  return [
+    { path: QURAN_PATH, priority: 0.9 },
+    ...SURAHS.map((s) => ({ path: surahPath(s.slug), priority: 0.8 })),
+    ...JUZ.map((j) => ({ path: juzPath(j.n), priority: 0.7 })),
+    ...HIZB.map((h) => ({ path: hizbPath(h.n), priority: 0.6 })),
+    ...Array.from({ length: TOTAL_PAGES }, (_, i) => ({
+      path: mushafPath(i + 1),
+      priority: 0.5,
+    })),
+  ];
+}
+
+
+/** The surah's name in the reader's own script: "Al-Kahf" / "الكهف". Using
+ * the transliteration inside Arabic copy would be both ugly and unsearchable. */
+export function surahName(locale: Locale, s: SurahMeta): string {
+  return locale === "ar" ? bareArabic(s.arabic).replace(/^سورة\s*/, "") : s.translit;
+}
+
+export function juzName(locale: Locale, n: number): string {
+  const j = JUZ[n - 1];
+  return locale === "ar" ? bareArabic(j.arabic) : j.translit;
+}
+
+/** "Surah Al-Kahf 18:10" / "سورة الكهف 18:10". */
+export function verseRef(locale: Locale, surah: number, ayah: number): string {
+  const b = getDict(locale).quranBrowse;
+  return `${b.surah} ${surahName(locale, SURAHS[surah - 1])} ${surah}:${ayah}`;
+}
+
+/** A readable list of surah names, for descriptions that span several. */
+export function surahListLabel(locale: Locale, numbers: number[]): string {
+  const b = getDict(locale).quranBrowse;
+  const names = numbers.map((n) => `${b.surah} ${surahName(locale, SURAHS[n - 1])}`);
+  return joinNames(locale, names);
+}
+
+/** Same list without the "Surah" prefix — for titles, where every character
+ * counts against the ~60 Google will actually show. */
+export function shortSurahList(locale: Locale, numbers: number[]): string {
+  const names = numbers.slice(0, 2).map((n) => surahName(locale, SURAHS[n - 1]));
+  const label = joinNames(locale, names);
+  return numbers.length > 2 ? `${label}…` : label;
+}
+
+function joinNames(locale: Locale, names: string[]): string {
+  if (names.length <= 1) return names[0] ?? "";
+  const tail = locale === "ar" ? " و" : " & ";
+  return `${names.slice(0, -1).join(locale === "ar" ? "، " : ", ")}${tail}${names.at(-1)}`;
+}
+
+const BOOK_NAME: Record<Locale, string> = {
+  en: "The Holy Quran",
+  ar: "القرآن الكريم",
+};
+
+/** trailingSlash is on, so the canonical form carries the slash. Structured
+ * data must point at the same URL the <link rel="canonical"> does. */
+const abs = (locale: Locale, path: string) => `${SITE_URL}${localePath(locale, path)}/`;
+
+type Crumb = { name: string; path: string };
+
+function breadcrumbs(locale: Locale, trail: Crumb[]) {
+  const d = getDict(locale);
+  const items: Crumb[] = [
+    { name: "Falah.io", path: "" },
+    { name: d.tools.quran.title, path: QURAN_PATH },
+    ...trail,
+  ];
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((c, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: c.name,
+      item: abs(locale, c.path),
+    })),
+  };
+}
+
+/** Structured data for one reading unit. `Chapter` is only strictly right for
+ * a surah; juz, hizb and mushaf pages are described as parts of the same Book
+ * so search engines can see how the four views relate. */
+export function readingJsonLd({
+  locale,
+  path,
+  name,
+  description,
+  crumb,
+  isChapter = false,
+  position,
+}: {
+  locale: Locale;
+  path: string;
+  name: string;
+  description: string;
+  crumb: string;
+  isChapter?: boolean;
+  position?: number;
+}) {
+  const url = abs(locale, path);
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebPage",
+        name,
+        description,
+        url,
+        inLanguage: locale,
+        isPartOf: { "@type": "WebSite", name: "Falah.io", url: SITE_URL },
+        breadcrumb: breadcrumbs(locale, [{ name: crumb, path }]),
+        mainEntity: {
+          "@type": isChapter ? "Chapter" : "CreativeWork",
+          name,
+          ...(position ? { position } : {}),
+          inLanguage: "ar",
+          isPartOf: { "@type": "Book", name: BOOK_NAME[locale], inLanguage: "ar" },
+        },
+      },
+    ],
+  };
+}
+
+/** The hub at /quran: an explicit machine-readable index of all 114 surahs,
+ * which is the single strongest signal that the deeper routes exist. */
+export function quranHubJsonLd(locale: Locale) {
+  const d = getDict(locale);
+  const b = d.quranBrowse;
+  const url = abs(locale, QURAN_PATH);
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebPage",
+        name: d.tools.quran.meta.title,
+        description: d.tools.quran.meta.description,
+        url,
+        inLanguage: locale,
+        isPartOf: { "@type": "WebSite", name: "Falah.io", url: SITE_URL },
+        breadcrumb: breadcrumbs(locale, []),
+      },
+      {
+        "@type": "Book",
+        name: BOOK_NAME[locale],
+        inLanguage: "ar",
+        numberOfPages: TOTAL_PAGES,
+        url,
+        hasPart: SURAHS.map((s) => ({
+          "@type": "Chapter",
+          position: s.n,
+          name: `${b.surah} ${surahName(locale, s)}`,
+          alternateName: s.arabic,
+          url: abs(locale, surahPath(s.slug)),
+        })),
+      },
+      {
+        "@type": "ItemList",
+        name: b.hubJuzTitle,
+        numberOfItems: JUZ.length,
+        itemListElement: JUZ.map((j) => ({
+          "@type": "ListItem",
+          position: j.n,
+          name: `${b.juz} ${j.n} — ${juzName(locale, j.n)}`,
+          url: abs(locale, juzPath(j.n)),
+        })),
+      },
+    ],
+  };
+}

--- a/locales/ar/index.ts
+++ b/locales/ar/index.ts
@@ -4,6 +4,7 @@ import { meta } from "./meta";
 import { home } from "./home";
 import { about } from "./about";
 import { tools } from "./tools";
+import { quranBrowse } from "./tools/quran-browse";
 
 export const ar: typeof en = {
   code: "ar",
@@ -14,4 +15,5 @@ export const ar: typeof en = {
   home,
   about,
   tools,
+  quranBrowse,
 };

--- a/locales/ar/tools/quran-browse.ts
+++ b/locales/ar/tools/quran-browse.ts
@@ -1,0 +1,93 @@
+import type { quranBrowse as en } from "../../en/tools/quran-browse";
+
+/** The `name` arguments arrive already in Arabic (see surahName / juzName in
+ * lib/quran-seo.ts) — never a Latin transliteration. `meaning` is the English
+ * gloss and is deliberately unused here. */
+export const quranBrowse: typeof en = {
+  quran: "القرآن الكريم",
+  surah: "سورة",
+  juz: "الجزء",
+  hizb: "الحزب",
+  page: "الصفحة",
+  verses: "آية",
+  verse: "الآية",
+  meccan: "مكية",
+  medinan: "مدنية",
+  readInReader: "افتح في المصحف التفاعلي",
+  listen: "استمع إلى التلاوة",
+  prev: "السابق",
+  next: "التالي",
+  backToQuran: "القرآن الكريم كاملًا",
+
+  navigate: "التنقل",
+  browseBy: "طريقة التصفح",
+  bySurah: "سورة",
+  byJuz: "جزء",
+  byHizb: "حزب",
+  byPage: "صفحة",
+  translationList: "التفسير، آيةً آية",
+
+  hubSurahsTitle: "سور القرآن الكريم الـ114",
+  hubSurahsP:
+    "جميع سور القرآن الكريم بترتيب المصحف. كل سورة في صفحة كاملة بالرسم العثماني مع التفسير الميسّر وتلاوة آيةً آية.",
+  hubJuzTitle: "أجزاء القرآن الثلاثون",
+  hubJuzP:
+    "القرآن الكريم مقسّمًا إلى ثلاثين جزءًا — ورد القراءة الذي يُختم به القرآن في شهر، ولا سيّما في رمضان.",
+  hubHizbTitle: "أحزاب القرآن الستون",
+  hubHizbP: "كل جزء مقسوم إلى حزبين، لمن يتابع ورده اليومي بالحزب.",
+  hubPagesTitle: "صفحات المصحف الـ604",
+  hubPagesP:
+    "كل صفحات مصحف المدينة بالترقيم المطبوع نفسه — تعين على الحفظ وعلى المتابعة مع المصحف الورقي.",
+  showAllPages: "تصفّح الصفحات الـ604",
+
+  surahTitle: (name: string, _meaning: string, n: number) => `سورة ${name} — السورة ${n} كاملة`,
+  surahDesc: (
+    name: string,
+    n: number,
+    _meaning: string,
+    ayahs: number,
+    revelation: string,
+    juz: number,
+  ) =>
+    `اقرأ سورة ${name} كاملة — السورة رقم ${n} في المصحف — بالرسم العثماني مع التفسير الميسّر. ${ayahs} آية، ${revelation}، تبدأ في الجزء ${juz}. مجانًا، بلا إعلانات وبلا حساب.`,
+  surahH1: (name: string) => `سورة ${name}`,
+  surahIntro: (
+    name: string,
+    n: number,
+    _meaning: string,
+    ayahs: number,
+    revelation: string,
+    juz: number,
+    page: number,
+  ) =>
+    `سورة ${name} هي السورة رقم ${n} في ترتيب المصحف، وهي سورة ${revelation} عدد آياتها ${ayahs} آية، تبدأ في الجزء ${juz} عند الصفحة ${page} من المصحف. وفيما يلي نصها كاملًا بالرسم العثماني مع تفسير كل آية.`,
+
+  juzTitle: (n: number, name: string) => `الجزء ${n} (${name}) كاملًا مع التفسير`,
+  juzDesc: (n: number, name: string, from: string, to: string, ayahs: number) =>
+    `اقرأ الجزء ${n} من القرآن الكريم (${name}) من ${from} إلى ${to} — ${ayahs} آية بالرسم العثماني مع التفسير والتلاوة. مجانًا وبلا إعلانات.`,
+  juzH1: (n: number) => `الجزء ${n}`,
+  juzIntro: (n: number, name: string, from: string, to: string, ayahs: number, surahs: number) =>
+    `الجزء ${n} — ويُعرف بـ«${name}» نسبةً إلى أول كلماته — هو أحد أجزاء القرآن الثلاثين. يمتد من ${from} إلى ${to}، ويضم ${ayahs} آية في ${surahs === 1 ? "سورة واحدة" : `${surahs} سور`}. وقراءة جزء كل يوم تُتِم ختمة في شهر.`,
+
+  hizbTitle: (n: number, juz: number) => `الحزب ${n} (الجزء ${juz}) كاملًا مع التفسير`,
+  hizbDesc: (n: number, juz: number, from: string, to: string, ayahs: number) =>
+    `اقرأ الحزب ${n} من القرآن الكريم، وهو ${n % 2 === 1 ? "النصف الأول" : "النصف الثاني"} من الجزء ${juz}، من ${from} إلى ${to} — ${ayahs} آية بالرسم العثماني مع التفسير.`,
+  hizbH1: (n: number) => `الحزب ${n}`,
+  hizbIntro: (n: number, juz: number, from: string, to: string, ayahs: number) =>
+    `الحزب ${n} هو ${n % 2 === 1 ? "النصف الأول" : "النصف الثاني"} من الجزء ${juz}، وأحد أحزاب القرآن الستين. يمتد من ${from} إلى ${to} ويضم ${ayahs} آية.`,
+
+  pageTitle: (n: number, surahs: string, juz: number) =>
+    `صفحة ${n} من المصحف — ${surahs}، الجزء ${juz}`,
+  pageDesc: (n: number, juz: number, surahs: string, ayahs: number) =>
+    `اقرأ الصفحة ${n} من القرآن الكريم (${surahs}، الجزء ${juz}) كما هي في مصحف المدينة المطبوع — ${ayahs} آية بالرسم العثماني مع التفسير والتلاوة.`,
+  pageH1: (n: number) => `صفحة ${n} من المصحف`,
+  pageIntro: (n: number, juz: number, surahs: string, ayahs: number) =>
+    `الصفحة ${n} من مصحف المدينة ذي الـ604 صفحات تقع في الجزء ${juz} وتضم ${ayahs} آية من ${surahs}. ونهاية الصفحة هنا مطابقة للمصحف المطبوع، فيمكنك المتابعة مع نسختك الورقية أو ضبط ورد الحفظ صفحةً صفحة.`,
+
+  alsoIn: "في هذا الموضع من المصحف",
+  juzOfSurah: (n: number) => `الجزء ${n}`,
+  pageOfSurah: (n: number) => `الصفحة ${n}`,
+  surahsOnThisPage: "السور في هذه الصفحة",
+  startsAt: "تبدأ عند",
+  ayahCount: (n: number) => `${n} آية`,
+};

--- a/locales/en/index.ts
+++ b/locales/en/index.ts
@@ -3,6 +3,7 @@ import { meta } from "./meta";
 import { home } from "./home";
 import { about } from "./about";
 import { tools } from "./tools";
+import { quranBrowse } from "./tools/quran-browse";
 
 export const en = {
   code: "en",
@@ -13,4 +14,5 @@ export const en = {
   home,
   about,
   tools,
+  quranBrowse,
 };

--- a/locales/en/tools/quran-browse.ts
+++ b/locales/en/tools/quran-browse.ts
@@ -1,0 +1,109 @@
+/** Copy for the prerendered Quran routes — /quran/surah/…, /juz/…, /hizb/…
+ * and /page/…. Kept apart from the reader's UI strings because almost all of
+ * it is search-facing: titles, meta descriptions and body prose that Google
+ * reads, not chrome. */
+export const quranBrowse = {
+  // ---- shared labels ----
+  quran: "Quran",
+  surah: "Surah",
+  juz: "Juz",
+  hizb: "Hizb",
+  page: "Page",
+  verses: "verses",
+  verse: "Verse",
+  meccan: "Meccan",
+  medinan: "Medinan",
+  readInReader: "Open in the interactive reader",
+  listen: "Listen to this recitation",
+  prev: "Previous",
+  next: "Next",
+  backToQuran: "All of the Quran",
+
+  // ---- reader navigation ----
+  navigate: "Navigate",
+  browseBy: "Browse by",
+  bySurah: "Surah",
+  byJuz: "Juz",
+  byHizb: "Hizb",
+  byPage: "Page",
+  translationList: "Translation, verse by verse",
+
+  // ---- the hub: /quran ----
+  hubSurahsTitle: "All 114 surahs",
+  hubSurahsP:
+    "Every surah of the Holy Quran, in order of the mushaf. Each one opens as a full page with the Uthmani Arabic, an English translation and verse-by-verse audio.",
+  hubJuzTitle: "The 30 juz (para)",
+  hubJuzP:
+    "The Quran divided into its 30 juz — the reading portions used to complete the Quran across a month, especially in Ramadan.",
+  hubHizbTitle: "The 60 hizb",
+  hubHizbP: "Each juz split in two, for readers who track their daily portion by hizb.",
+  hubPagesTitle: "All 604 mushaf pages",
+  hubPagesP:
+    "Every page of the standard Madani mushaf, numbered exactly as in print — useful for memorisation and for following along with a physical copy.",
+  showAllPages: "Browse all 604 pages",
+
+  // ---- surah pages ----
+  // Titles stay under ~50 characters: the site template appends "— Falah.io",
+  // and Google only shows about 60.
+  surahTitle: (name: string, meaning: string, n: number) =>
+    `Surah ${name} (${meaning}) — Quran chapter ${n}`,
+  surahDesc: (
+    translit: string,
+    n: number,
+    meaning: string,
+    ayahs: number,
+    revelation: string,
+    juz: number,
+  ) =>
+    `Read Surah ${translit} — surah ${n} of the Quran, "${meaning}" — in Uthmani Arabic with an English translation. ${ayahs} verses, ${revelation}, begins in juz ${juz}. Free, no ads, no account.`,
+  surahH1: (translit: string) => `Surah ${translit}`,
+  surahIntro: (
+    translit: string,
+    n: number,
+    meaning: string,
+    ayahs: number,
+    revelation: string,
+    juz: number,
+    page: number,
+  ) =>
+    `Surah ${translit} is the ${ordinal(n)} surah of the Quran. Its name means “${meaning}”. It is a ${revelation.toLowerCase()} surah of ${ayahs} verses, opening in juz ${juz} on page ${page} of the mushaf. Below is the full Arabic text in Uthmani script with an English translation for every verse.`,
+
+  // ---- juz pages ----
+  juzTitle: (n: number, name: string) => `Juz ${n} (${name}) — full text & translation`,
+  juzDesc: (n: number, translit: string, from: string, to: string, ayahs: number) =>
+    `Read juz ${n} of the Quran (${translit}), from ${from} to ${to} — ${ayahs} verses in Uthmani Arabic with an English translation and audio. Free, no ads, no account.`,
+  juzH1: (n: number) => `Juz ${n}`,
+  juzIntro: (n: number, translit: string, from: string, to: string, ayahs: number, surahs: number) =>
+    `Juz ${n} — known as ${translit} after its opening words — is the ${ordinal(n)} of the Quran's 30 reading portions. It runs from ${from} to ${to}, covering ${ayahs} verses across ${surahs === 1 ? "one surah" : `${surahs} surahs`}. Reading one juz a day completes the Quran in a month.`,
+
+  // ---- hizb pages ----
+  hizbTitle: (n: number, juz: number) => `Hizb ${n} (Juz ${juz}) — full text & translation`,
+  hizbDesc: (n: number, juz: number, from: string, to: string, ayahs: number) =>
+    `Read hizb ${n} of the Quran, the ${n % 2 === 1 ? "first" : "second"} half of juz ${juz}, from ${from} to ${to} — ${ayahs} verses in Uthmani Arabic with an English translation.`,
+  hizbH1: (n: number) => `Hizb ${n}`,
+  hizbIntro: (n: number, juz: number, from: string, to: string, ayahs: number) =>
+    `Hizb ${n} is the ${n % 2 === 1 ? "first" : "second"} half of juz ${juz}, one of the 60 hizb the Quran is divided into. It runs from ${from} to ${to} and contains ${ayahs} verses.`,
+
+  // ---- mushaf page routes ----
+  pageTitle: (n: number, surahs: string, juz: number) =>
+    `Quran page ${n} — ${surahs}, juz ${juz}`,
+  pageDesc: (n: number, juz: number, surahs: string, ayahs: number) =>
+    `Read page ${n} of the Quran (${surahs}, juz ${juz}) exactly as printed in the Madani mushaf — ${ayahs} verses in Uthmani Arabic with an English translation and audio.`,
+  pageH1: (n: number) => `Quran page ${n}`,
+  pageIntro: (n: number, juz: number, surahs: string, ayahs: number) =>
+    `Page ${n} of the standard 604-page Madani mushaf falls in juz ${juz} and contains ${ayahs} verses from ${surahs}. The page break matches the printed mushaf, so you can follow along with a physical copy or track a memorisation plan page by page.`,
+
+  // ---- cross-links between the four views ----
+  alsoIn: "Also in this part of the Quran",
+  juzOfSurah: (n: number) => `Juz ${n}`,
+  pageOfSurah: (n: number) => `Page ${n}`,
+  surahsOnThisPage: "Surahs on this page",
+  startsAt: "Starts at",
+  ayahCount: (n: number) => `${n} ${n === 1 ? "verse" : "verses"}`,
+};
+
+function ordinal(n: number): string {
+  const rest = n % 100;
+  if (rest >= 11 && rest <= 13) return `${n}th`;
+  return `${n}${["th", "st", "nd", "rd"][n % 10] ?? "th"}`;
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "node scripts/fetch-quran.mjs",
     "dev": "next dev",
+    "prebuild": "node scripts/fetch-quran.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"

--- a/scripts/fetch-quran.mjs
+++ b/scripts/fetch-quran.mjs
@@ -1,0 +1,47 @@
+/**
+ * Downloads the Quran editions the prerendered routes are built from.
+ *
+ * Runs once as `prebuild`. `next build` fans out across ~11 worker
+ * processes, and every one of them renders some of the ~1,600 Quran routes —
+ * without this step each worker would fetch all three editions itself, which
+ * is ~40 requests for 14 MB of identical data and gets refused by the API.
+ *
+ * Cached files are reused, so repeat builds do no network I/O at all. Delete
+ * .quran-cache/ to force a refresh.
+ */
+
+import { mkdir, readdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const API = "https://api.alquran.cloud/v1/quran";
+const DIR = join(process.cwd(), ".quran-cache");
+
+// The Arabic text, plus the translation each locale's dictionary asks for.
+const EDITIONS = ["quran-uthmani", "en.sahih", "ar.muyassar"];
+const TOTAL_AYAHS = 6236;
+
+async function fetchEdition(edition) {
+  const res = await fetch(`${API}/${edition}`);
+  if (!res.ok) throw new Error(`${edition}: HTTP ${res.status}`);
+  const json = await res.json();
+  const count = json?.data?.surahs?.reduce((n, s) => n + s.ayahs.length, 0) ?? 0;
+  if (count !== TOTAL_AYAHS) {
+    throw new Error(`${edition}: expected ${TOTAL_AYAHS} ayahs, got ${count}`);
+  }
+  return json;
+}
+
+await mkdir(DIR, { recursive: true });
+const present = new Set(await readdir(DIR).catch(() => []));
+
+for (const edition of EDITIONS) {
+  const file = `${edition}.json`;
+  if (present.has(file)) {
+    console.log(`quran: ${edition} already cached`);
+    continue;
+  }
+  process.stdout.write(`quran: fetching ${edition}… `);
+  const json = await fetchEdition(edition);
+  await writeFile(join(DIR, file), JSON.stringify(json));
+  console.log("ok");
+}


### PR DESCRIPTION
- Add `quran-page.ts` to assemble Quran routes for different views (surah, juz, hizb, page).
- Introduce `quran-reader.ts` for shared types and helpers for the Quran reader.
- Create `quran-seo.ts` for managing URLs, titles, and structured data for Quran routes.
- Enhance Arabic and English locale files to include Quran browsing translations.
- Implement a script `fetch-quran.mjs` to download Quran editions for prerendered routes.
- Update `package.json` to run the fetch script before development and build processes.

## What & why

<!-- One or two sentences. Link the issue if one exists: Fixes #123 -->

## Checklist

- [x] `npm run lint`, `npx tsc --noEmit`, and `npm run build` all pass
- [x] Copy changes made in **every** `locales/*.ts` (en + ar)
- [x] UI checked in Arabic (RTL) and dark mode
- [x] Islamic content cites its source (if applicable)
